### PR TITLE
dstripe Improvements

### DIFF
--- a/doc/markdown/dstripe.1.md
+++ b/doc/markdown/dstripe.1.md
@@ -6,7 +6,7 @@ dstripe - restripe files on underlying storage
 
 # SYNOPSIS
 
-**dstripe STRIPE_COUNT STRIPE_SIZE SRC_FILE DEST_FILE**
+**dstripe [OPTION] SRC_FILE**
 
 # DESCRIPTION
 
@@ -16,23 +16,43 @@ This tool is in active development.  It will eventually report striping informat
 
 dstripe enables one to restripe a file across the underlying storage devices.  dstripe will make a full copy of the source file with the new striping parameters and write it to the destination file.
 
+One must specify the source file (SRC_FILE) to perform a restripe with. By default, stripe size is 1MB and stripe count is -1 allowing dstripe to use all available stipes.
+
 One must specify the integer number of stripes as the first parameter in STRIPE_COUNT.  One can specify -1 to use all available stripes.  One must specify the stripe size in bytes in STRIPE_SIZE.  It is possible to use units like "MB" or "GB" after the number.  The units should come immediately after the number without spaces.  Then one must give the source file in SRC_FILE and the name for the new file in DEST_FILE.
 
 # OPTIONS
+
+-o, \--output DEST_FILE
+:	Write the restriped file to DEST_FILE. If DEST_FILE is equivalent to SRC_FILE, the restriped file overwrites SRC_FILE. Otherwise, SRC_FILE will not be removed after restriping.
+
+-c, \--count STRIPE_COUNT
+:	The number of stripes to use when restriping SRC_FILE. If STRIPE_COUNT is -1, then all available stripes are used. The default stripe count is -1.
+
+-s, \--size STRIPE_SIZE
+:	The stripe size to use during restriping. It is possible to use units like "MB" and "GB" after the number (ex. 2MB). The default stripe size is 1MB.
+
+-r, \--report
+:	Display the stripe count and stripe size of SRC_FILE. No restriping is performed when using this option.
+
+-v, \--verbose
+: 	Run in verbose mode.
+
+-h, \--help
+: 	Print the command usage, and the list of options available.
 
 # EXAMPLES
 
 1. To stripe a file on all storage devices using a 1MB stripe size:
 
-mpirun -np 128 dstripe -1 1MB /path/to/file /path/to/file2
+mpirun -np 128 dstripe -s 1MB /path/to/file
 
 2. To stripe a file across 20 storage devices with a 1GB stripe size:
 
-mpirun -np 128 dstripe 20 2GBB /path/to/file /path/to/file2
+mpirun -np 128 dstripe -c 20 -s 1GB -o /path/to/file2 /path/to/file
 
-3. To read the current striping parameters of a file on Lustre:
+3. To display the current stripe count and stripe size of a file:
 
-lfs getstripe /path/to/file
+dstripe -r /path/to/file
 
 # SEE ALSO
 

--- a/src/dstripe/dstripe.c
+++ b/src/dstripe/dstripe.c
@@ -50,6 +50,7 @@ static void print_usage(void)
     printf("  -c, --count            - stripe count (default -1)\n");
     printf("  -s, --size             - stripe size in bytes (default 1MB)\n");
     printf("  -r, --report           - input file stripe info\n");
+    printf("  -v, --verbose          - verbose output\n");
     printf("  -h, --help             - print usage\n");
     printf("\n");
     fflush(stdout);
@@ -69,6 +70,7 @@ int main(int argc, char* argv[])
     int option_index = 0;
     int usage = 0;
     int report = 0;
+    int verbose = 0;
     int stripes = -1;
     int delete_input = 0;
     unsigned long long stripe_size = 1048576;
@@ -87,7 +89,7 @@ int main(int argc, char* argv[])
     };
 
     while (1) {
-        int c = getopt_long(argc, argv, "o:c:s:rh",
+        int c = getopt_long(argc, argv, "o:c:s:rhv",
                     long_options, &option_index);
 
         if (c == -1) {
@@ -116,6 +118,10 @@ int main(int argc, char* argv[])
             case 'r':
                 /* report striping info */
 		report = 1;
+                break;
+            case 'v':
+                /* verbose output */
+                verbose = 1;
                 break;
             case 'h':
                 /* display usage */
@@ -228,6 +234,13 @@ int main(int argc, char* argv[])
         }
     }
 #endif
+
+    if (verbose) {
+        if (rank == 0) {
+            printf("Input File: %s\nOutput File: %s\n",
+                in_path, out_path);
+        }
+    }
 
     MPI_Barrier(MPI_COMM_WORLD);
 


### PR DESCRIPTION
Number of improvements to dstripe in this pull request. List below.

- Add a --report flag to display file stripe size and stripe count
- Make stripe count and stripe size optional by giving them reasonable defaults
- No longer require that an output file path be provided
- Lay the ground work for a verbose flag (this can use further work)
- Update the documentation to reflect the new state of the tool