### PR TITLE
dstripe's report option should print file size

### DIFF
--- a/doc/markdown/dstripe.1.md
+++ b/doc/markdown/dstripe.1.md
@@ -28,7 +28,7 @@ dstripe enables one to restripe a file across the underlying storage devices. On
 :	The minimum size a file must be to be a candidate for restriping. It is possible to use units like "MB" and "GB" after the number, which should be immediately follow the number without spaces (ex. 2MB). The default minimum file size is 0MB.
 
 -r, \--report
-:	Display the stripe count and stripe size of all files found in PATH. No restriping is performed when using this option.
+:	Display the file size, stripe count, and stripe size of all files found in PATH. No restriping is performed when using this option.
 
 -v, \--verbose
 : 	Run in verbose mode.


### PR DESCRIPTION
Enable dstripe to print a file's size when using the
--report/-r option.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>

@adammoody I think the report option might be producing too much text. Do you have a preferred format to print a files info? I can incorporate it into this PR.