### PR TITLE
Rename website from fileutils to mpifileutils

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Fileutils - Parallel file utilities for HPC</title>
+    <title>mpiFileutils - Parallel file utilities for HPC</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="css/min.css" rel="stylesheet">
 
@@ -20,13 +20,13 @@
         <div class="demo-headline col-md-6">
           <h1 class="demo-logo">
             <div class="logo"></div>
-            FileUtils
+            mpiFileUtils
             <small>File Utilities For Distributed Systems</small>
           </h1>
         </div>
         <div class="demo-headline col-md-3">
           <p><img src="images/icons/svg/retina.svg"></p>
-          <a href="https://github.com/hpc/fileutils/releases" class="btn btn-primary btn-lg btn-block">Download Now</a>
+          <a href="https://github.com/hpc/mpifileutils/releases" class="btn btn-primary btn-lg btn-block">Download Now</a>
         </div>
       </div>
       <div class="row demo-tiles">
@@ -64,7 +64,11 @@
     <footer>
       <div class="container">
         <div class="row">
-          <div class="col-md-7">
+          <div class="col-md-7">            
+<!--
+
+Disable the mailing list links for now -- are these still active? Do they need to be renamed?
+
             <h3 class="footer-title">Subscribe</h3>
             <p>
             Discuss Mailing List: <a href="https://groups.google.com/d/forum/fileutils-discuss" target="_blank">groups.google.com/fileutils-discuss</a><br/>
@@ -73,9 +77,10 @@
             </p>
 
             <p class="pvl">
-              <iframe src="http://ghbtns.com/github-btn.html?user=hpc&repo=fileutils&type=watch&count=true" height="20" width="107" frameborder="0" scrolling="0" style="width:105px; height: 20px;" allowTransparency="true"></iframe>
-              <iframe src="http://ghbtns.com/github-btn.html?user=hpc&repo=fileutils&type=fork&count=true" height="20" width="107" frameborder="0" scrolling="0" style="width:105px; height: 20px;" allowTransparency="true"></iframe>
+              <iframe src="http://ghbtns.com/github-btn.html?user=hpc&repo=mpifileutils&type=watch&count=true" height="20" width="107" frameborder="0" scrolling="0" style="width:105px; height: 20px;" allowTransparency="true"></iframe>
+              <iframe src="http://ghbtns.com/github-btn.html?user=hpc&repo=mpifileutils&type=fork&count=true" height="20" width="107" frameborder="0" scrolling="0" style="width:105px; height: 20px;" allowTransparency="true"></iframe>
             </p>
+-->
 
           </div> <!-- /col-md-7 -->
 
@@ -88,7 +93,7 @@
                   <li>Request Features.</li>
                   <li>Write documentation.</li>
               </ul>
-              Go to: <a href="https://github.com/hpc/fileutils" target="_blank">github.com/hpc/fileutils</a>
+              Go to: <a href="https://github.com/hpc/mpifileutils" target="_blank">github.com/hpc/mpifileutils</a>
             </div>
           </div>
         </div>
@@ -109,14 +114,5 @@
     <script src="js/jquery.stacktable.js"></script>
     <script src="http://vjs.zencdn.net/4.1/video.js"></script>
     <script src="js/application.js"></script>
-
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-37488386-2', 'fileutils.io');
-      ga('send', 'pageview');
-    </script>
   </body>
 </html>


### PR DESCRIPTION
- Rename from fileutils to mpifileutils.
- Remove (likely outdated) mailing list links.
- Remove google analytics tracking code for the old fileutils.io