### PR TITLE
adding code to track if read error was on src or dest side

### DIFF
--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -749,7 +749,7 @@ static void dcmp_strmap_compare_data(
              * they could be the same, but we'll draw attention to them this way */
             rc = 1;
             MFU_LOG(MFU_LOG_ERR,
-              "Failed to read.  Asumming contents are different.");
+              "Failed to open, lseek, or read.  Asumming contents are different.");
 
             /* consider this to be a fatal error if syncing */
             if (mfu_copy_opts->do_sync) {

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -497,7 +497,6 @@ static int dcmp_compare_data(
         MFU_LOG(MFU_LOG_ERR, "Failed to lseek %s, offset: %x, error msg: %s",  
           dst_name, (unsigned int)offset, strerror(errno));
         mfu_close(dst_name, dst_fd);
-        mfu_close(dst_name, dst_fd);
         mfu_close(src_name, src_fd);
         return -1;
     }

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -454,9 +454,9 @@ static int dcmp_compare_data(
     /* open source file */
     int src_fd = mfu_open(src_name, O_RDONLY);
     if (src_fd < 0) {
-       if (src_fd < 0) { 
-           *is_src_err = 1;
-       } 
+       /* set is_src_err in so we know the 
+        * open failure was on the src side */
+       *is_src_err = 1;
        return -1;
     }
 
@@ -478,6 +478,8 @@ static int dcmp_compare_data(
     if (mfu_lseek(src_name, src_fd, offset, SEEK_SET) == (off_t)-1) {
         mfu_close(dst_name, dst_fd);
         mfu_close(src_name, src_fd);
+
+        /* set is_src_err so we know lseek failure was on the src side */
         *is_src_err = 1;
         return -1;
     }

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -484,7 +484,7 @@ static int dcmp_compare_data(
        /* log error if there is an lseek failure on the 
         * src side */
         MFU_LOG(MFU_LOG_ERR, "Failed to lseek %s, offset: %x, error msg: %s",
-          src_name, (unsigned int)offset, strerror(errno));
+          src_name, (unsigned long)offset, strerror(errno));
         mfu_close(dst_name, dst_fd);
         mfu_close(src_name, src_fd);
         return -1;
@@ -495,7 +495,7 @@ static int dcmp_compare_data(
        /* log error if there is an lseek failure on the 
         * dst side */
         MFU_LOG(MFU_LOG_ERR, "Failed to lseek %s, offset: %x, error msg: %s",  
-          dst_name, (unsigned int)offset, strerror(errno));
+          dst_name, (unsigned long)offset, strerror(errno));
         mfu_close(dst_name, dst_fd);
         mfu_close(src_name, src_fd);
         return -1;

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -455,7 +455,9 @@ static int dcmp_compare_data(
     if (src_fd < 0) {
        /* log error if there is an open failure on the 
         * src side */
-       MFU_LOG(MFU_LOG_ERR, "Failed to open %s", src_name);
+        MFU_LOG(MFU_LOG_ERR, "Failed to open %s, error msg: %s", 
+          src_name, strerror(errno));
+        mfu_close(src_name, src_fd);
        return -1;
     }
 
@@ -464,7 +466,8 @@ static int dcmp_compare_data(
     if (dst_fd < 0) {
        /* log error if there is an open failure on the 
         * dst side */
-        MFU_LOG(MFU_LOG_ERR, "Failed to open %s", dst_name);
+        MFU_LOG(MFU_LOG_ERR, "Failed to open %s, error msg: %s", 
+          dst_name, strerror(errno));
         mfu_close(src_name, src_fd);
         return -1;
     }
@@ -480,7 +483,8 @@ static int dcmp_compare_data(
     if (mfu_lseek(src_name, src_fd, offset, SEEK_SET) == (off_t)-1) {
        /* log error if there is an lseek failure on the 
         * src side */
-        MFU_LOG(MFU_LOG_ERR, "Failed to lseek %s", src_name);
+        MFU_LOG(MFU_LOG_ERR, "Failed to lseek %s, offset: %x, error msg: %s",
+          src_name, (unsigned int)offset, strerror(errno));
         mfu_close(dst_name, dst_fd);
         mfu_close(src_name, src_fd);
         return -1;
@@ -490,7 +494,9 @@ static int dcmp_compare_data(
     if(mfu_lseek(dst_name, dst_fd, offset, SEEK_SET) == (off_t)-1) {
        /* log error if there is an lseek failure on the 
         * dst side */
-        MFU_LOG(MFU_LOG_ERR, "Failed to lseek %s", dst_name);
+        MFU_LOG(MFU_LOG_ERR, "Failed to lseek %s, offset: %x, error msg: %s",  
+          dst_name, (unsigned int)offset, strerror(errno));
+        mfu_close(dst_name, dst_fd);
         mfu_close(dst_name, dst_fd);
         mfu_close(src_name, src_fd);
         return -1;
@@ -528,13 +534,15 @@ static int dcmp_compare_data(
             /* hit a read error, now figure out if it was the 
              * src or dest, and print file */
             if (src_read < 0) { 
-                MFU_LOG(MFU_LOG_ERR, "Failed to read %s", src_name);
+                MFU_LOG(MFU_LOG_ERR, "Failed to read %s, error msg: %s", 
+                  src_name, strerror(errno));
             } 
             /* added this extra check in case both are less 
              * than zero -- we'd want both files read 
              * errors reported */
             if (dst_read < 0) {
-                MFU_LOG(MFU_LOG_ERR, "Failed to read %s", dst_name);
+                MFU_LOG(MFU_LOG_ERR, "Failed to read %s, error msg: %s", 
+                  dst_name, strerror(errno));
             } 
             rc = -1;
             break;

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -529,7 +529,11 @@ static int dcmp_compare_data(
              * src or dest, and print file */
             if (src_read < 0) { 
                 MFU_LOG(MFU_LOG_ERR, "Failed to read %s", src_name);
-            } else {
+            } 
+            /* added this extra check in case both are less 
+             * than zero -- we'd want both files read 
+             * errors reported */
+            if (dst_read < 0) {
                 MFU_LOG(MFU_LOG_ERR, "Failed to read %s", dst_name);
             } 
             rc = -1;
@@ -749,7 +753,8 @@ static void dcmp_strmap_compare_data(
              * they could be the same, but we'll draw attention to them this way */
             rc = 1;
             MFU_LOG(MFU_LOG_ERR,
-              "Failed to open, lseek, or read.  Asumming contents are different.");
+              "Failed to open, lseek, or read %s and/or %s. Assuming contents are different.",
+                 src_p->name, dst_p->name);
 
             /* consider this to be a fatal error if syncing */
             if (mfu_copy_opts->do_sync) {


### PR DESCRIPTION
* added code to dcmp_strmap_compare_data & dcmp_compare_data to track whether or not the open file/reading errors were on the src or dest side