### PR TITLE
Resolve wrapping of mpiFileUtils on homepage

### DIFF
--- a/css/min.css
+++ b/css/min.css
@@ -7216,10 +7216,12 @@ td.visible-print {
   padding: 60px 0 5px;
   text-align: center;
 }
-.demo-logo {
+.demo-logo .logo {
   font: 900 90px/100px "Helvetica Neue", Helvetica, Arial, sans-serif;
   letter-spacing: -2px;
   margin: 10px 0;
+  overflow: hidden;
+  white-space: nowrap;
 }
 /*
 .demo-logo .logo {

--- a/index.html
+++ b/index.html
@@ -19,8 +19,7 @@
         <div class="col-md-1"></div>
         <div class="demo-headline col-md-6">
           <h1 class="demo-logo">
-            <div class="logo"></div>
-            mpiFileUtils
+            <div class="logo">mpiFileUtils</div>
             <small>MPI-Based File Utilities For Distributed Systems</small>
           </h1>
         </div>


### PR DESCRIPTION
Tweak css so the mpiFileUtils doesn't wrap on
index.html.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>
Closes #82