### PR TITLE
dcp runs against input flist is broken now

### DIFF
--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -168,7 +168,13 @@ void mfu_flist_walk_param_paths(
 /* skip function pointer: given a path input, along with user-provided
  * arguments, compute whether to enqueue this file in output list of
  * mfu_flist_stat, return 1 if file should be skipped, 0 if not. */
-typedef int (*mfu_flist_skip_fn) (const char* path, void* args);
+typedef int (*mfu_flist_skip_fn) (const char* path, void *args);
+
+/* skip function args */
+struct mfu_flist_skip_args {
+    int numpaths;
+    const mfu_param_path* paths;
+};
 
 /* Given an input file list, stat each file and enqueue details
  * in output file list, skip entries excluded by skip function
@@ -311,8 +317,7 @@ void mfu_flist_copy(mfu_flist src_cp_list, int numpaths,
 /* unlink all items in flist */
 void mfu_flist_unlink(mfu_flist flist);
 
-int mfu_input_flist_skip(const char* name, int numpaths,
-        const mfu_param_path* paths);
+int mfu_input_flist_skip(const char* name, void *args);
 
 /* sort flist by specified fields, given as common-delimitted list
  * precede field name with '-' character to reverse sort order:

--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -108,17 +108,24 @@ static mfu_copy_stats_t mfu_copy_stats;
 static mfu_copy_file_cache_t mfu_copy_src_cache;
 static mfu_copy_file_cache_t mfu_copy_dst_cache;
 
-int mfu_input_flist_skip(const char* name, int numpaths,
-        const mfu_param_path* paths)
+int mfu_input_flist_skip(const char* name, void *args)
 {
+    struct mfu_flist_skip_args *sk_args;
     /* create mfu_path from name */
     const mfu_path* path = mfu_path_from_str(name);
 
+    if (args == NULL) {
+        MFU_LOG(MFU_LOG_INFO, "Skip %s.", name);
+        return 1;
+    }
+
+    sk_args =  (struct mfu_flist_skip_args *)args;
+
     /* iterate over each source path */
     int i;
-    for (i = 0; i < numpaths; i++) {
+    for (i = 0; i < sk_args->numpaths; i++) {
         /* create mfu_path of source path */
-        const char* src_name = paths[i].path;
+        const char* src_name = sk_args->paths[i].path;
         const mfu_path* src_path = mfu_path_from_str(src_name);
 
         /* check whether path is contained within or equal to


### PR DESCRIPTION
# dcp --input=/tmp/file_diff_2 -d dbg -p -v /tmp/dir0/0/ /tmp/dir1/0/
[2017-09-28T14:49:37] [0] [../../../src/dcp/dcp.c:179] Using input list.
[2017-09-28T14:49:37] [0] [../../../src/dcp/dcp.c:157] Debug level set to: debug
[2017-09-28T14:49:37] [0] [../../../src/dcp/dcp.c:185] Preserving file attributes.

Usage: dcp [options] source target
       dcp [options] source ... target_dir

Options:
  -i, --input <file>  - read source list from file
  -p, --preserve      - preserve permissions, ownership, timestamps, extended attributes
  -s, --synchronous   - use synchronous read/write calls (O_DIRECT)
  -S, --sparse        - create sparse files when possible
  -v, --verbose       - verbose output
  -h, --help          - print usage
