### PR TITLE
dcmp: add permission comparison support

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = common dbcast dcmp dchmod dcp ddup dfilemaker drm dstripe dwalk
+SUBDIRS = common dbcast dcmp dchmod dcp ddup dfilemaker drm dwalk

--- a/src/common/mfu_flist.c
+++ b/src/common/mfu_flist.c
@@ -678,6 +678,12 @@ uint64_t mfu_flist_file_get_mode(mfu_flist bflist, uint64_t idx)
     return mode;
 }
 
+uint64_t mfu_flist_file_get_perm(mfu_flist bflist, uint64_t idx) {
+    uint64_t mode = mfu_flist_file_get_mode(bflist, idx);
+
+    return mode & (S_IRWXU | S_IRWXG | S_IRWXO);
+}
+
 uint64_t mfu_flist_file_get_uid(mfu_flist bflist, uint64_t idx)
 {
     uint64_t ret = (uint64_t) - 1;

--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -274,6 +274,7 @@ uint64_t mfu_flist_file_get_mtime_nsec(mfu_flist flist, uint64_t index);
 uint64_t mfu_flist_file_get_ctime(mfu_flist flist, uint64_t index);
 uint64_t mfu_flist_file_get_ctime_nsec(mfu_flist flist, uint64_t index);
 uint64_t mfu_flist_file_get_size(mfu_flist flist, uint64_t index);
+uint64_t mfu_flist_file_get_perm(mfu_flist flist, uint64_t index);
 const char* mfu_flist_file_get_username(mfu_flist flist, uint64_t index);
 const char* mfu_flist_file_get_groupname(mfu_flist flist, uint64_t index);
 

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -93,6 +93,7 @@ typedef enum _dcmp_field {
     DCMPF_ATIME,     /* both have the same atime */
     DCMPF_MTIME,     /* both have the same mtime */
     DCMPF_CTIME,     /* both have the same ctime */
+    DCMPF_PERM,      /* both have the same permission */
     DCMPF_CONTENT,   /* both have the same data */
     DCMPF_MAX,
 } dcmp_field;
@@ -105,6 +106,7 @@ typedef enum _dcmp_field {
 #define DCMPF_ATIME_DEPEND   (DCMPF_EXIST_DEPEND | (1 << DCMPF_ATIME))
 #define DCMPF_MTIME_DEPEND   (DCMPF_EXIST_DEPEND | (1 << DCMPF_MTIME))
 #define DCMPF_CTIME_DEPEND   (DCMPF_EXIST_DEPEND | (1 << DCMPF_CTIME))
+#define DCMPF_PERM_DEPEND    (DCMPF_EXIST_DEPEND | (1 << DCMPF_PERM))
 #define DCMPF_CONTENT_DEPEND (DCMPF_SIZE_DEPEND | (1 << DCMPF_CONTENT))
 
 uint64_t dcmp_field_depend[] = {
@@ -116,6 +118,7 @@ uint64_t dcmp_field_depend[] = {
     [DCMPF_ATIME]   = DCMPF_ATIME_DEPEND,
     [DCMPF_MTIME]   = DCMPF_MTIME_DEPEND,
     [DCMPF_CTIME]   = DCMPF_CTIME_DEPEND,
+    [DCMPF_PERM]   = DCMPF_PERM_DEPEND,
     [DCMPF_CONTENT] = DCMPF_CONTENT_DEPEND,
 };
 
@@ -226,6 +229,13 @@ static const char* dcmp_field_to_string(dcmp_field field, int simple)
             return "CTIME";
         } else {
             return "change time";
+        }
+        break;
+    case DCMPF_PERM:
+        if (simple) {
+            return "PERM";
+        } else {
+            return "permission";
         }
         break;
     case DCMPF_CONTENT:
@@ -664,6 +674,9 @@ static int dcmp_compare_metadata(
     }
     if (dcmp_option_need_compare(DCMPF_CTIME)) {
         dcmp_compare_field(ctime, DCMPF_CTIME);
+    }
+    if (dcmp_option_need_compare(DCMPF_PERM)) {
+        dcmp_compare_field(ctime, DCMPF_PERM);
     }
 
     return diff;


### PR DESCRIPTION
dcmp: add permission comparison support

-o PERM=DIFFER...

Signed-off-by: Gu Zheng <cengku@gmail.com>