### PR TITLE
Addback dstripe to Makefile which deleted by mistake

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = common dbcast dcmp dchmod dcp ddup dfilemaker drm dwalk
+SUBDIRS = common dbcast dcmp dchmod dcp ddup dfilemaker drm dstripe dwalk


### PR DESCRIPTION
commit ff71ec4605b084575e6bed507eaa7e6ac244a2f3 deleted dstripe from Makefile.am
(by mistake), here added it back.

Signed-off-by: Gu Zheng <cengku@gmail.com>