### PR TITLE
mfu common: Append a force sync after data copy

### DIFF
--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -1432,6 +1432,10 @@ void mfu_flist_copy(mfu_flist src_cp_list, int numpaths,
     mfu_copy_close_file(&mfu_copy_src_cache);
     mfu_copy_close_file(&mfu_copy_dst_cache);
 
+    /* force the copy to backend, to avoid the following metadata
+     * setting mismatch, which may happen on lustre */
+    sync();
+
     /* set permissions, ownership, and timestamps if needed */
     mfu_copy_set_metadata(levels, minlevel, lists, numpaths,
             paths, destpath, mfu_copy_opts);


### PR DESCRIPTION
https://github.com/hpc/mpifileutils/issues/94

As on lustre, when the file closed, the data may not be synced to
backend immediately, so if update the timestamps during this gap,
that may cause the timestamps mismatch finally, so we add a force
sync after data copy, before we setting timestamps on the dest files,
to avoid this potential issue.

Signed-off-by: Gu Zheng <cengku@gmail.com>