### PR TITLE
dcmp: correct the call function of permission compare

### DIFF
--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -676,7 +676,7 @@ static int dcmp_compare_metadata(
         dcmp_compare_field(ctime, DCMPF_CTIME);
     }
     if (dcmp_option_need_compare(DCMPF_PERM)) {
-        dcmp_compare_field(ctime, DCMPF_PERM);
+        dcmp_compare_field(perm, DCMPF_PERM);
     }
 
     return diff;


### PR DESCRIPTION
     if (dcmp_option_need_compare(DCMPF_PERM)) {
         dcmp_compare_field(ctime, DCMPF_PERM);
     }

It's typo here, permission compare should compare the perm filed,
not the ctime, correct it here.

Signed-off-by: Gu Zheng <cengku@gmail.com>