### PR TITLE
dcp: add pure copy mode support

### DIFF
--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -573,6 +573,12 @@ static int mfu_create_directory(mfu_flist list, uint64_t idx,
         return 0;
     }
 
+    /* Skipping the destination directory */
+    if (strncmp(dest_path, destpath->path, strlen(dest_path)) == 0) {
+        mfu_free(&dest_path);
+        return 0;
+    }
+
    /* create the destination directory */
     MFU_LOG(MFU_LOG_DBG, "Creating directory `%s'", dest_path);
     int rc = mfu_mkdir(dest_path, DCOPY_DEF_PERMS_DIR);

--- a/src/common/mfu_param_path.c
+++ b/src/common/mfu_param_path.c
@@ -534,7 +534,8 @@ char* mfu_param_path_copy_dest(const char* name, int numpaths,
      * otherwise cut all components listed in source path */
     int cut = src_components;
     if (mfu_copy_opts->copy_into_dir && cut > 0) {
-        if (mfu_copy_opts->do_sync != 1) {
+        if ((mfu_copy_opts->do_sync != 1) ||
+            (paths[i].orig[strlen(paths[i].orig) - 1] != '/')) {
             cut--;
         }
     }


### PR DESCRIPTION
Add pure mode support pure mode, e.g. if src ends with trailing slash, don't create additional
directory level at the destination, just copy sub dirs/files under src, similar to "rsync /foo/bar/ /foo1/".

Signed-off-by: Gu Zheng <cengku@gmail.com>