### PR TITLE
mfu: skip the output dump if no items in the list

### DIFF
--- a/src/common/mfu_flist_io.c
+++ b/src/common/mfu_flist_io.c
@@ -1289,18 +1289,23 @@ void mfu_flist_write_cache(
     /* start timer */
     double start_write = MPI_Wtime();
 
+    /* total list items */
+    uint64_t all_count = mfu_flist_global_size(flist);
+
     /* report the filename we're writing to */
     if (mfu_debug_level >= MFU_LOG_VERBOSE && mfu_rank == 0) {
         printf("Writing to output file: %s\n", name);
         fflush(stdout);
     }
 
-    if (flist->detail) {
-        write_cache_stat(name, 0, 0, flist);
-    }
-    else {
-        //write_cache_readdir(name, 0, 0, flist);
-        write_cache_readdir_variable(name, flist);
+    if (all_count > 0) {
+        if (flist->detail) {
+            write_cache_stat(name, 0, 0, flist);
+        }
+        else {
+            //write_cache_readdir(name, 0, 0, flist);
+            write_cache_readdir_variable(name, flist);
+        }
     }
 
     /* end timer */
@@ -1308,7 +1313,6 @@ void mfu_flist_write_cache(
 
     /* report write count, time, and rate */
     if (mfu_debug_level >= MFU_LOG_VERBOSE && mfu_rank == 0) {
-        uint64_t all_count = mfu_flist_global_size(flist);
         double secs = end_write - start_write;
         double rate = 0.0;
         if (secs > 0.0) {


### PR DESCRIPTION
Skip the output dump if no itmes in the list, otherwise it will crash like following:

sending incremental file list

sent 31937 bytes  received 160 bytes  64194.00 bytes/sec
total size is 27350230  speedup is 852.11

Files which have different modification times, number: 0/0

dcmp works properly, but it fails if it dumps to file if there are nothing differ

 *** An error occurred in MPI_Type_get_extent
 *** reported by process [139900657664001,0]
 *** on communicator MPI_COMM_WORLD
 *** MPI_ERR_TYPE: invalid datatype
 *** MPI_ERRORS_ARE_FATAL (processes in this communicator will now abort,
 ***    and potentially your MPI job)

Signed-off-by: Gu Zheng <cengku@gmail.com>