### PR TITLE
Dcmp improve

### DIFF
--- a/src/common/mfu_flist.c
+++ b/src/common/mfu_flist.c
@@ -217,6 +217,18 @@ static size_t list_elem_unpack2(const void* buf, elem_t* elem)
     return bytes;
 }
 
+/* fake insert, just increase the count, used for counting */
+void mfu_flist_increase(mfu_flist* pbflist)
+{
+    /* convert handle to flist_t */
+    flist_t* flist = *(flist_t**)pbflist;
+
+    /* increase list count by one */
+    flist->list_count++;
+
+    return;
+}
+
 /* append element to tail of linked list */
 void mfu_flist_insert_elem(flist_t* flist, elem_t* elem)
 {

--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -201,6 +201,9 @@ void mfu_flist_write_cache(
 /* free resouces in file list */
 void mfu_flist_free(mfu_flist* flist);
 
+/* fake insert, just increase the count, used for counting */
+void mfu_flist_increase(mfu_flist* pblist);
+
 /* given an input list, split items into separate lists depending
  * on their depth, returns number of levels, minimum depth, and
  * array of lists as output */

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -664,7 +664,13 @@ static int dcmp_compare_metadata(
     int diff = 0;
 
     if (dcmp_option_need_compare(DCMPF_SIZE)) {
-        dcmp_compare_field(size, DCMPF_SIZE);
+        mfu_filetype type = mfu_flist_file_get_type(src_list, src_index);
+        if (type != MFU_TYPE_DIR) {
+            dcmp_compare_field(size, DCMPF_SIZE);
+        } else {
+            dcmp_strmap_item_update(src_map, key, DCMPF_SIZE, DCMPS_COMMON);
+            dcmp_strmap_item_update(dst_map, key, DCMPF_SIZE, DCMPS_COMMON);
+        }
     }
     if (dcmp_option_need_compare(DCMPF_GID)) {
         dcmp_compare_field(gid, DCMPF_GID);

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -51,6 +51,9 @@ static void print_usage(void)
     printf("  -b, --base  - do base comparison\n");
     printf("  -o, --output field0=state0@field1=state1,field2=state2:file "
     	   "- write list to file\n");
+    printf("       multiple output files supports, e.g.\n");
+    printf("       -o EXIST=ONLY_SRC,TYPE=DIFFER,PERM=DIFFER,MTIME=DIFFER:"
+           "fileA -o MTIME=DIFFER:fileB\n");
     printf("  -v, --verbose\n");
     printf("  -h, --help  - print usage\n");
     printf("\n");


### PR DESCRIPTION
Here are some minor improvements for dcmp.
"dcmp: improve the usage() 
dcmp: print the matched count of each conjunctions group in summary"
These two are used to improve the usage and summary log, in order to make it more friendly to users.

"dcmp: record the rawtime directly rather than converting from wtime"
This patch uses localtime() to record the time rather than MPI_Wtime (with additional conversion), to avoid some unexpected condition, e.g. time overflow.

"dcmp: skip the size differ check for dir"
This commit remove the size differ check for dir, as we are focusing the size check of files, not dirs, and on the other hand, size of dir may be different even contained files are the same, depends on the fs.

Please refer to the commits for details.