### PR TITLE
Correct detection of Lustre API

### DIFF
--- a/m4/lx_find_lustre.m4
+++ b/m4/lx_find_lustre.m4
@@ -1,26 +1,45 @@
-# looks for lustre header files
-# if found, defines LUSTRE_SUPPORT=1 in config.h
+dnl #
+dnl # Determines if Lustre API is installed.
+dnl # Checks if Lustre API has llapi_layout.
+dnl #
 AC_DEFUN([X_AC_LUSTRE], [
-  AC_MSG_CHECKING([whether to enable Lustre support])
-  AC_ARG_ENABLE([lustre],
-                AC_HELP_STRING([--enable-lustre], [enable Lustre support]),
-                [], [enable_lustre="no"])
-  AC_MSG_RESULT([$enable_lustre])
+	AC_ARG_ENABLE(lustre,
+		AC_HELP_STRING([--enable-lustre],
+		[enable Lustre support]),
+		[], [enable_lustre=no])
 
-  if [[ "x$enable_lustre" == xyes ]]; then
-    AC_MSG_CHECKING([for Lustre])
-    AS_IF([test -e "/usr/include/lustre/lustre_user.h" && test -e "/usr/include/lustre/lustreapi.h"],
-          [lustre_available="yes"],
-          [lustre_available="no"])
-    AC_MSG_RESULT([$lustre_available])
+	AS_CASE(["x$enable_lustre"],
+		["xcheck"],
+		[lustre_found="yes"],
+		["xyes"],
+		[lustre_found="yes"],
+		["xno"],
+		[lustre_found="no"],
+		[AC_MSG_ERROR([Unknown option $enable_lustre])])
 
-  #  AC_SEARCH_LIBS([llapi_file_create], [lustreapi], [], [
-  #    AC_MSG_ERROR([couldn't find liblustreapi])], [])
 
-    AS_IF([test "x$lustre_available" = xyes], [
-      AC_DEFINE(LUSTRE_SUPPORT, 1, [enable Lustre support])
-      LUSTRE_LIBS="-llustreapi"
-      AC_SUBST(LUSTRE_LIBS)
-    ])
-  fi
+	if test "x$enable_lustre" != xno; then
+		AC_CHECK_HEADERS([lustre/lustre_user.h lustre/lustreapi.h],
+			[], [lustre_found="no"], [])
+
+		if test "x$lustre_found" != "xno"; then
+			AC_DEFINE([LUSTRE_SUPPORT], [1],
+			    [Define to 1 if Lustre can be used])
+			LUSTRE_LIBS="-llustreapi"
+			AC_SUBST(LUSTRE_LIBS)
+
+			AC_CHECK_LIB(
+			    [lustreapi],
+			    [llapi_layout_alloc],
+			    [AC_DEFINE([HAVE_LLAPI_LAYOUT], [1],
+			        [Define to 1 if llapi_layout can be used.])],
+			    [], [])
+		fi
+	fi
+
+	AC_MSG_CHECKING([whether to enable Lustre support])
+	if test "x$lustre_found" = "xno" && test "xenable_lustre" = xyes; then
+		AC_MSG_ERROR([Lustre libraries are not available.])
+	fi
+	AC_MSG_RESULT([$lustre_found])
 ])

--- a/src/dstripe/dstripe.c
+++ b/src/dstripe/dstripe.c
@@ -80,7 +80,7 @@ static void generate_suffix(char *suffix, const int len)
 /* uses the lustre api to obtain stripe count and stripe size of a file */
 static int get_file_stripe_info(const char *path, uint64_t *stripe_size, uint64_t *stripe_count)
 {
-#ifdef LUSTRE_SUPPORT
+#ifdef HAVE_LLAPI_LAYOUT
     /* obtain the llapi_layout for a file by path */
     struct llapi_layout *layout = llapi_layout_get_by_path(path, 0);
 
@@ -103,7 +103,7 @@ static int get_file_stripe_info(const char *path, uint64_t *stripe_size, uint64_
 /* create a striped lustre file at the path provided with the specified stripe size and count */
 static void create_striped_file(const char *path, uint64_t stripe_size, int stripe_count)
 {
-#ifdef LUSTRE_SUPPORT
+#ifdef HAVE_LLAPI_LAYOUT
     /* create a new llapi_layout for file creation */
     struct llapi_layout *layout = llapi_layout_alloc();
     int fd = -1;
@@ -502,7 +502,17 @@ int main(int argc, char* argv[])
     /* nothing to do if lustre support is disabled */
 #ifndef LUSTRE_SUPPORT
     if (rank == 0) {
-        printf("Lustre support is disabled\n");
+        printf("Lustre support is disabled.\n");
+        fflush(stdout);
+    }
+
+    MPI_Abort(MPI_COMM_WORLD, 1);
+#endif
+
+#ifndef HAVE_LLAPI_LAYOUT
+    /* nothing to do if lustre doesn't support llapi_layouts */
+    if (rank == 0) {
+        printf("dstripe requires Lustre 2.7 and above.\n");
         fflush(stdout);
     }
 


### PR DESCRIPTION
Correct lx_find_lustre.m4 to properly check for
header files. Also check that 'llapi_layout_alloc' is
a function in the Lustre API because dstripe currently
depends on it.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>