### PR TITLE
dcmp: add ACL comparison support

### DIFF
--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -284,6 +284,9 @@ uint64_t mfu_flist_file_get_ctime(mfu_flist flist, uint64_t index);
 uint64_t mfu_flist_file_get_ctime_nsec(mfu_flist flist, uint64_t index);
 uint64_t mfu_flist_file_get_size(mfu_flist flist, uint64_t index);
 uint64_t mfu_flist_file_get_perm(mfu_flist flist, uint64_t index);
+#if DCOPY_USE_XATTRS
+void *mfu_flist_file_get_acl(mfu_flist bflist, uint64_t idx, ssize_t *acl_size, char *type);
+#endif
 const char* mfu_flist_file_get_username(mfu_flist flist, uint64_t index);
 const char* mfu_flist_file_get_groupname(mfu_flist flist, uint64_t index);
 


### PR DESCRIPTION
ACL(Access Control List) is widely used in modern file-systems, to support advanced
management.
So here we add a new comparison option named 'ACL' (-o ACL=DIFFER...) to support the ACL
comparison.
Following is a sample to use this feature:

```
 # getfacl /mnt/lustre/file_1
getfacl: Removing leading '/' from absolute path names
 # file: mnt/lustre/file_1
 # owner: root
 # group: root
user::rw-
user:ntp:rwx
group::r--
mask::rwx
other::r--

 # getfacl /mnt/lustre/file_2
getfacl: Removing leading '/' from absolute path names
 # file: mnt/lustre/file_2
 # owner: root
 # group: root
user::rw-
user:ntp:rwx
group::r--
mask::rwx
other::r--

 # ./install/bin/dcmp /mnt/lustre/file_1 /mnt/lustre/file_2 -o ACL=DIFFER
Files which have different Access Control Listss: [0/0]
ACLs are the same, so no diff found.

change the ACL of file_2 and run dcmp again:
 # setfacl -m u:rpc:rwx /mnt/lustre/file_2
 # getfacl /mnt/lustre/file_2
getfacl: Removing leading '/' from absolute path names
 # file: mnt/lustre/file_2
 # owner: root
 # group: root
user::rw-
user:rpc:rwx
user:ntp:rwx
group::r--
mask::rwx
other::r--

 # ./install/bin/dcmp /mnt/lustre/file_1 /mnt/lustre/file_2 -o ACL=DIFFER
Files which have different Access Control Listss: [1/1]

dcmp detected the diff.
```

Signed-off-by: Gu Zheng <cengku@gmail.com>