### PR TITLE
dbz2: add -lbz2 to Makefile

### DIFF
--- a/experimental/dbz2/Makefile.am
+++ b/experimental/dbz2/Makefile.am
@@ -6,4 +6,4 @@ noinst_HEADERS = dbz2.h
 dbz2_SOURCES = dbz2.c common_dbz2.c dbz2_func.c
 dbz2_CPPFLAGS = -I../../src/common/ $(MPI_CFLAGS) $(libcircle_CFLAGS) $(libarchive_CFLAGS)
 dbz2_LDFLAGS = $(MPI_CLDFLAGS)
-dbz2_LDADD = ../../src/common/libmfu.la $(MPI_CLDFLAGS) $(libcircle_LIBS) $(libarchive_LIBS)
+dbz2_LDADD = ../../src/common/libmfu.la $(MPI_CLDFLAGS) $(libcircle_LIBS) $(libarchive_LIBS) -lbz2


### PR DESCRIPTION
Add the link to bz2 lib to Makefile, otherwise the build may fail of
undefined function reference:
dbz2-common_dbz2.o: In function `DBz2_Dequeue':
../experimental/dbz2/common_dbz2.c:44: undefined reference to `BZ2_bzBuffToBuffCompress'
dbz2-common_dbz2.o: In function `DBz2_decompDequeue':
../../../experimental/dbz2/common_dbz2.c:139: undefined reference to `BZ2_bzBuffToBuffDecompress'
collect2: ld returned 1 exit status