### PR TITLE
drm: add traceless mode support

### DIFF
--- a/experimental/dsh/dsh.c
+++ b/experimental/dsh/dsh.c
@@ -2015,7 +2015,7 @@ int main(int argc, char** argv)
                 int inclusive = 1;
                 mfu_flist filtered, leftover;
                 filter_files_path(flist, remove_path, inclusive, &filtered, &leftover);
-                mfu_flist_unlink(filtered);
+                mfu_flist_unlink(filtered, false);
                 mfu_flist_free(&filtered);
 
                 /* to update our list after removing files above, set flist

--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -358,7 +358,7 @@ void mfu_flist_mkdir(mfu_flist flist);
 void mfu_flist_mknod(mfu_flist flist);
 
 /* unlink all items in flist */
-void mfu_flist_unlink(mfu_flist flist);
+void mfu_flist_unlink(mfu_flist flist, bool traceless);
 
 int mfu_input_flist_skip(const char* name, void *args);
 

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -1156,7 +1156,7 @@ static void dcmp_sync_files(strmap* src_map, strmap* dst_map,
      * and then remove those files */
     dcmp_only_dst(src_map, dst_map, dst_list, dst_remove_list);
     mfu_flist_summarize(dst_remove_list);
-    mfu_flist_unlink(dst_remove_list);
+    mfu_flist_unlink(dst_remove_list, false);
         
     /* summarize the src copy list for files 
      * that need to be copied into dest directory */ 

--- a/src/drm/drm.c
+++ b/src/drm/drm.c
@@ -62,6 +62,7 @@ static void print_usage(void)
     printf("      --name             - exclude a list of files from command\n");
     printf("      --dryrun           - print out list of files that would be deleted\n");
     printf("  -v, --verbose          - verbose output\n");
+    printf("  -T, --traceless        - traceless mode, remove the file, but keep parent dir's mtime nochange\n");
     printf("  -h, --help             - print usage\n");
     printf("\n");
     fflush(stdout);
@@ -88,6 +89,7 @@ int main(int argc, char** argv)
     int exclude     = 0;
     int name        = 0;
     int dryrun      = 0;
+    int traceless   = 0;
 
     int option_index = 0;
     static struct option long_options[] = {
@@ -98,6 +100,7 @@ int main(int argc, char** argv)
         {"name",     0, 0, 'n'},        
         {"dryrun",   0, 0, 'd'},
         {"verbose",  0, 0, 'v'},
+        {"traceless",  0, 0, 'T'},
         {"help",     0, 0, 'h'},
         {0, 0, 0, 0}
     };
@@ -105,7 +108,7 @@ int main(int argc, char** argv)
     int usage = 0;
     while (1) {
         int c = getopt_long(
-                    argc, argv, "i:lhv",
+                    argc, argv, "i:lhvT",
                     long_options, &option_index
                 );
 
@@ -137,6 +140,9 @@ int main(int argc, char** argv)
             case 'v':
                 mfu_debug_level = MFU_LOG_VERBOSE;
                 break;
+            case 'T':
+                traceless = 1;
+                break;            
             case 'h':
                 usage = 1;
                 break;
@@ -227,7 +233,7 @@ int main(int argc, char** argv)
         mfu_flist_print(srclist);
     } else {
         /* remove files */
-        mfu_flist_unlink(srclist);
+        mfu_flist_unlink(srclist, traceless);
     }
 
     /* free list if it was used */


### PR DESCRIPTION
Add traceless mode support to drm (-T/--traceless), if the option is enabled,
unlink file/dir/link will not change its parent dir's timestamp (atiem/mtime),
it is useful if some guy want to remove the extra files under dst dir after
a dcp, but not change the timestamp of the dst filesystem tree, in order to
keep the same as src.

Signed-off-by: Gu Zheng <cengku@gmail.com>