### PR TITLE
make use of text output fucntion

### DIFF
--- a/experimental/dsh/dsh.c
+++ b/experimental/dsh/dsh.c
@@ -1756,6 +1756,7 @@ int main(int argc, char** argv)
     char* inputname  = NULL;
     char* outputname = NULL;
     int walk = 0;
+    int text = 0;
     /* set print default to 25 for now */
     int print_default = 100;
 
@@ -1767,13 +1768,14 @@ int main(int argc, char** argv)
         {"lite",     0, 0, 'l'},
         {"help",     0, 0, 'h'},
         {"verbose",  0, 0, 'v'},
+        {"text",     0, 0, 't'},
         {0, 0, 0, 0}
     };
 
     int usage = 0;
     while (1) {
         int c = getopt_long(
-                    argc, argv, "f:i:o:lhv",
+                    argc, argv, "f:i:o:lhvt",
                     long_options, &option_index
                 );
 
@@ -1801,6 +1803,9 @@ int main(int argc, char** argv)
                 break;
             case 'v':
                 verbose = 1;
+                break;
+            case 't':
+                text = 1;
                 break;
             case '?':
                 usage = 1;
@@ -2065,7 +2070,11 @@ int main(int argc, char** argv)
 
     /* write data to cache file */
     if (outputname != NULL) {
-        mfu_flist_write_cache(outputname, flist);
+        if (!text) {
+            mfu_flist_write_cache(outputname, flist);
+        } else {
+            mfu_flist_write_text(outputname, flist);
+        }
     }
 
     /* free users, groups, and files objects */

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -156,6 +156,7 @@ struct dcmp_output {
 struct dcmp_options {
     struct list_head outputs;      /* list of outputs */
     int verbose;
+    int format;			   /* output data format, 0 for text, 1 for raw */
     int base;                      /* whether to do base check */
     int debug;                     /* check result after get result */
     int need_compare[DCMPF_MAX];   /* fields that need to be compared  */
@@ -164,6 +165,7 @@ struct dcmp_options {
 struct dcmp_options options = {
     .outputs      = LIST_HEAD_INIT(options.outputs),
     .verbose      = 0,
+    .format       = 1,
     .base         = 0,
     .debug        = 0,
     .need_compare = {0,}
@@ -2027,7 +2029,11 @@ static int dcmp_output_write(
     mfu_flist_summarize(src_matched);
     mfu_flist_summarize(dst_matched);
     if (output->file_name != NULL) {
-        mfu_flist_write_cache(output->file_name, new_flist);
+        if (options.format) {
+            mfu_flist_write_cache(output->file_name, new_flist);
+        } else {
+            mfu_flist_write_text(output->file_name, new_flist);
+        }
     }
 
     int rank;
@@ -2309,6 +2315,7 @@ int main(int argc, char **argv)
         {"debug",    0, 0, 'd'},
         {"output",   1, 0, 'o'},
         {"verbose",  0, 0, 'v'},
+        {"text",     0, 0, 't'},
         {"help",     0, 0, 'h'},
         {0, 0, 0, 0}
     };
@@ -2320,7 +2327,7 @@ int main(int argc, char **argv)
     int help  = 0;
     while (1) {
         int c = getopt_long(
-            argc, argv, "sbdo:vh",
+            argc, argv, "sbdo:vht",
             long_options, &option_index
         );
 
@@ -2347,6 +2354,9 @@ int main(int argc, char **argv)
         case 'v':
             options.verbose++;
             mfu_debug_level = MFU_LOG_VERBOSE;
+            break;
+        case 't':
+            options.format = 0;
             break;
         case 'h':
         case '?':

--- a/src/dwalk/dwalk.c
+++ b/src/dwalk/dwalk.c
@@ -399,6 +399,7 @@ int main(int argc, char** argv)
     char* distribution = NULL;
     int walk = 0;
     int print = 0;
+    int text = 0;
     struct distribute_option option;
 
     int option_index = 0;
@@ -411,13 +412,14 @@ int main(int argc, char** argv)
         {"print",        0, 0, 'p'},
         {"verbose",      0, 0, 'v'},
         {"help",         0, 0, 'h'},
+        {"text",         0, 0, 't'},
         {0, 0, 0, 0}
     };
 
     int usage = 0;
     while (1) {
         int c = getopt_long(
-                    argc, argv, "i:o:ls:d:pvh",
+                    argc, argv, "i:o:ls:d:pvht",
                     long_options, &option_index
                 );
 
@@ -446,6 +448,9 @@ int main(int argc, char** argv)
                 break;
             case 'v':
                 mfu_debug_level = MFU_LOG_VERBOSE;
+                break;
+            case 't':
+                text = 1;
                 break;
             case 'h':
                 usage = 1;
@@ -616,7 +621,11 @@ int main(int argc, char** argv)
 
     /* write data to cache file */
     if (outputname != NULL) {
-        mfu_flist_write_cache(outputname, flist);
+        if (!text) {
+            mfu_flist_write_cache(outputname, flist);
+        } else {
+            mfu_flist_write_text(outputname, flist);
+        }
     }
 
     /* free users, groups, and files objects */


### PR DESCRIPTION
Text output feature has been landed, let's make use of it, change text
to the default output format, and another option '-r/--raw' is introduced to
enable original native format.

Signed-off-by: Gu Zheng <cengku@gmail.com>