### PR TITLE
Fix parse error in dchmod

### DIFF
--- a/src/dchmod/dchmod.c
+++ b/src/dchmod/dchmod.c
@@ -283,6 +283,7 @@ static int parse_ugoa(const char* str, struct perms* p)
         } 
         else if (str[0] == 'a') {
             p->all = 1;
+            p->assume_all = 0;
         } 
         else {
             /* found an invalid character */


### PR DESCRIPTION
When using a+r for instance, dchmod was incorrectly parsing this
as something that specified no letter (i.e +r), which uses umask.
This was causing dchmod to incorrectly assign permissions when
using the "all" attribute.