### PR TITLE
Set errno = 0 before calling readdir()

### DIFF
--- a/src/common/mfu_io.c
+++ b/src/common/mfu_io.c
@@ -523,6 +523,7 @@ struct dirent* mfu_readdir(DIR* dirp)
     struct dirent* entry;
     int tries = MFU_IO_TRIES;
 retry:
+    errno = 0;
     entry = readdir(dirp);
     if (entry == NULL) {
         if (errno == EINTR || errno == EIO || errno == ENOENT) {


### PR DESCRIPTION
Technically speaking when calling readdir() "If  the  end  of  the
directory stream is reached, NULL is returned and errno is not changed."
Therefore if we want to test errno, we need to properly initialize it to zero
before calling readdir().
