### PR TITLE
dcp1: add to normal install for its alternative copy algorithm

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,7 @@ AC_CONFIG_FILES([Makefile                \
                  src/dchmod/Makefile     \
                  src/dcmp/Makefile       \
                  src/dcp/Makefile        \
+                 src/dcp1/Makefile        \
                  src/ddup/Makefile       \
                  src/dfilemaker/Makefile \
                  src/dfmake/Makefile     \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = common dbcast dcmp dchmod dcp ddup dfilemaker dfmake drm dstripe dwalk
+SUBDIRS = common dbcast dcmp dchmod dcp dcp1 ddup dfilemaker dfmake drm dstripe dwalk


### PR DESCRIPTION
Adding dcp1 back to regularly installed tools since its alternative copy algorithm can be useful for directories with lots of small files.