### PR TITLE
License Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,10 @@
 BSD 3-Clause License
 
 Copyright (c) 2018, Lawrence Livermore National Security, LLC
+Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC
+Copyright (2013-2015) UT-Battelle, LLC
+Copyright (c) 2015, DataDirect Networks, Inc.
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE
+++ b/LICENSE
@@ -1,85 +1,29 @@
----------------------
-Copyrights
----------------------
+BSD 3-Clause License
 
-Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
-  Produced at the Lawrence Livermore National Laboratory
-  Written by Adam Moody <moody20@llnl.gov>.
-  CODE-673838
-
-Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
-  (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
-
-Copyright (2013-2015) UT-Battelle, LLC under Contract No.
-DE-AC05-00OR22725 with the Department of Energy.
-
-Copyright (c) 2015, DataDirect Networks, Inc.
-
+Copyright (c) 2018, Lawrence Livermore National Security, LLC
 All rights reserved.
-
-This file is part of the mpiFileUtils project.
-For details, see https://github.com/hpc/fileutils.
-Also see the Additional BSD Notice below.
-
----------------------
-BSD License
----------------------
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-   * Redistributions of source code must retain the above copyright
-     notice, this list of conditions and the following disclaimer.
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
 
-   * Redistributions in binary form must reproduce the above copyright
-     notice, this list of conditions and the following disclaimer in the
-     documentation and/or other materials provided with the distribution.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
 
-   * Neither the names of LLNS/LLNL; Los Alamos National Security, LLC;
-     Los Alamos National Laboratory; LANL; UT-Battelle, LLC; DataDirect
-     Networks, Inc.; the U.S. Government; nor the names of its contributors
-     may be used to endorse or promote products derived from this software
-     without specific prior written permission.
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY, LLC; LOS
-ALAMOS NATIONAL SECURITY, LLC; UT-BATTELLE, LLC; DataDirect Networks, Inc.;
-OR THE U.S. GOVERNMENT OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
-OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
----------------------
-Additional BSD Notice
----------------------
-
-1. This notice is required to be provided under our contract with the U.S.
-   Department of Energy (DOE). This work was produced at Lawrence Livermore
-   National Laboratory under Contract No. DE-AC52-07NA27344 with the DOE,
-   by Los Alamos National Laboratory (LANL) under U.S. Government contract
-   DE-AC52-06NA25396, and by UT-Battelle, LLC under Contract No.
-   DE-AC-00OR22725 with the DOE.
-
-2. Neither the United States Government, nor Lawrence Livermore National
-   Security, LLC, nor Los Alamos National Security, LLC, nor UT-Battelle, LLC,
-   nor DataDirect Networks, Inc., nor any of their employees, makes any warranty,
-   express or implied, or assumes any liability or responsibility for the
-   accuracy, completeness, or usefulness of any information, apparatus, product,
-   or process disclosed, or represents that its use would not infringe
-   privately-owned rights.
-
-3. Also, reference herein to any specific commercial products, process, or
-   services by trade name, trademark, manufacturer or otherwise does not
-   necessarily constitute or imply its endorsement, recommendation, or
-   favoring by the United States Government; Lawrence Livermore National
-   Security, LLC; Los Alamos National Security, LLC; UT-Battelle, LLC; or
-   DataDirect Networks, Inc. The views and opinions of authors expressed
-   herein do not necessarily state or reflect those of the United States
-   Government; Lawrence Livermore National Security, LLC; Los Alamos National
-   Security, LLC; UT-Battelle, LLC; or DataDirect Networks, Inc. and shall
-   not be used for advertising or product endorsement purposes.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,85 @@
+---------------------
+Copyrights
+---------------------
+
+Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
+  Produced at the Lawrence Livermore National Laboratory
+  Written by Adam Moody <moody20@llnl.gov>.
+  CODE-673838
+
+Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
+  (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
+
+Copyright (2013-2015) UT-Battelle, LLC under Contract No.
+DE-AC05-00OR22725 with the Department of Energy.
+
+Copyright (c) 2015, DataDirect Networks, Inc.
+
+All rights reserved.
+
+This file is part of the mpiFileUtils project.
+For details, see https://github.com/hpc/fileutils.
+Also see the Additional BSD Notice below.
+
+---------------------
+BSD License
+---------------------
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+   * Neither the names of LLNS/LLNL; Los Alamos National Security, LLC;
+     Los Alamos National Laboratory; LANL; UT-Battelle, LLC; DataDirect
+     Networks, Inc.; the U.S. Government; nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY, LLC; LOS
+ALAMOS NATIONAL SECURITY, LLC; UT-BATTELLE, LLC; DataDirect Networks, Inc.;
+OR THE U.S. GOVERNMENT OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---------------------
+Additional BSD Notice
+---------------------
+
+1. This notice is required to be provided under our contract with the U.S.
+   Department of Energy (DOE). This work was produced at Lawrence Livermore
+   National Laboratory under Contract No. DE-AC52-07NA27344 with the DOE,
+   by Los Alamos National Laboratory (LANL) under U.S. Government contract
+   DE-AC52-06NA25396, and by UT-Battelle, LLC under Contract No.
+   DE-AC-00OR22725 with the DOE.
+
+2. Neither the United States Government, nor Lawrence Livermore National
+   Security, LLC, nor Los Alamos National Security, LLC, nor UT-Battelle, LLC,
+   nor DataDirect Networks, Inc., nor any of their employees, makes any warranty,
+   express or implied, or assumes any liability or responsibility for the
+   accuracy, completeness, or usefulness of any information, apparatus, product,
+   or process disclosed, or represents that its use would not infringe
+   privately-owned rights.
+
+3. Also, reference herein to any specific commercial products, process, or
+   services by trade name, trademark, manufacturer or otherwise does not
+   necessarily constitute or imply its endorsement, recommendation, or
+   favoring by the United States Government; Lawrence Livermore National
+   Security, LLC; Los Alamos National Security, LLC; UT-Battelle, LLC; or
+   DataDirect Networks, Inc. The views and opinions of authors expressed
+   herein do not necessarily state or reflect those of the United States
+   Government; Lawrence Livermore National Security, LLC; Los Alamos National
+   Security, LLC; UT-Battelle, LLC; or DataDirect Networks, Inc. and shall
+   not be used for advertising or product endorsement purposes.

--- a/NOTICE
+++ b/NOTICE
@@ -1,85 +1,21 @@
----------------------
-Copyrights
----------------------
+This work was produced under the auspices of the U.S. Department of Energy by
+- Lawrence Livermore National Laboratory under Contract DE-AC52-07NA27344,
+- Los Alamos National Laboratory under Contract DE-AC52-06NA25396,
+- UT-Battelle, LLC under Contract DE-AC-00OR22725 with the DOE.
 
-Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
-  Produced at the Lawrence Livermore National Laboratory
-  Written by Adam Moody <moody20@llnl.gov>.
-  CODE-673838
-
-Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
-  (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
-
-Copyright (2013-2015) UT-Battelle, LLC under Contract No.
-DE-AC05-00OR22725 with the Department of Energy.
-
-Copyright (c) 2015, DataDirect Networks, Inc.
-
-All rights reserved.
-
-This file is part of the mpiFileUtils project.
-For details, see https://github.com/hpc/fileutils.
-Also see the Additional BSD Notice below.
-
----------------------
-BSD License
----------------------
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-   * Redistributions of source code must retain the above copyright
-     notice, this list of conditions and the following disclaimer.
-
-   * Redistributions in binary form must reproduce the above copyright
-     notice, this list of conditions and the following disclaimer in the
-     documentation and/or other materials provided with the distribution.
-
-   * Neither the names of LLNS/LLNL; Los Alamos National Security, LLC;
-     Los Alamos National Laboratory; LANL; UT-Battelle, LLC; DataDirect
-     Networks, Inc.; the U.S. Government; nor the names of its contributors
-     may be used to endorse or promote products derived from this software
-     without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY, LLC; LOS
-ALAMOS NATIONAL SECURITY, LLC; UT-BATTELLE, LLC; DataDirect Networks, Inc.;
-OR THE U.S. GOVERNMENT OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
-OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
----------------------
-Additional BSD Notice
----------------------
-
-1. This notice is required to be provided under our contract with the U.S.
-   Department of Energy (DOE). This work was produced at Lawrence Livermore
-   National Laboratory under Contract No. DE-AC52-07NA27344 with the DOE,
-   by Los Alamos National Laboratory (LANL) under U.S. Government contract
-   DE-AC52-06NA25396, and by UT-Battelle, LLC under Contract No.
-   DE-AC-00OR22725 with the DOE.
-
-2. Neither the United States Government, nor Lawrence Livermore National
-   Security, LLC, nor Los Alamos National Security, LLC, nor UT-Battelle, LLC,
-   nor DataDirect Networks, Inc., nor any of their employees, makes any warranty,
-   express or implied, or assumes any liability or responsibility for the
-   accuracy, completeness, or usefulness of any information, apparatus, product,
-   or process disclosed, or represents that its use would not infringe
-   privately-owned rights.
-
-3. Also, reference herein to any specific commercial products, process, or
-   services by trade name, trademark, manufacturer or otherwise does not
-   necessarily constitute or imply its endorsement, recommendation, or
-   favoring by the United States Government; Lawrence Livermore National
-   Security, LLC; Los Alamos National Security, LLC; UT-Battelle, LLC; or
-   DataDirect Networks, Inc. The views and opinions of authors expressed
-   herein do not necessarily state or reflect those of the United States
-   Government; Lawrence Livermore National Security, LLC; Los Alamos National
-   Security, LLC; UT-Battelle, LLC; or DataDirect Networks, Inc. and shall
-   not be used for advertising or product endorsement purposes.
+This work was prepared as an account of work sponsored by an agency of the
+United States Government. Neither the United States Government nor Lawrence
+Livermore National Security, LLC, nor Los Alamos National Security, LLC, nor
+UT-Battelle, LLC, nor any of their employees makes any warranty,
+expressed or implied, or assumes any legal liability or responsibility for the
+accuracy, completeness, or usefulness of any information, apparatus, product, or
+process disclosed, or represents that its use would not infringe privately owned
+rights. Reference herein to any specific commercial product, process, or service
+by trade name, trademark, manufacturer, or otherwise does not necessarily
+constitute or imply its endorsement, recommendation, or favoring by the United
+States Government, Lawrence Livermore National Security, LLC, Los Alamos Security,
+LLC, UT-Battelle, LLC, or DataDirect Networks, Inc. The views and
+opinions of authors expressed herein do not necessarily state or reflect those
+of the United States Government, Lawrence Livermore National Security, LLC, Los
+Alamos Security, LLC, UT-Battelle, LLC, or DataDirect Networks, Inc.
+and shall not be used for advertising or product endorsement purposes.

--- a/README.md
+++ b/README.md
@@ -97,5 +97,22 @@ it should be provided in the common library.
 ## Contributors
 We welcome contributions to the project.  For details on how to help, see our [Contributor Guide](.github/CONTRIBUTORS.md)
 
+### Copyrights
+
+Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
+  Produced at the Lawrence Livermore National Laboratory
+  Written by Adam Moody <moody20@llnl.gov>.
+  CODE-673838
+
+Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
+  (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
+
+Copyright (2013-2015) UT-Battelle, LLC under Contract No.
+DE-AC05-00OR22725 with the Department of Energy.
+
+Copyright (c) 2015, DataDirect Networks, Inc.
+
+All rights reserved.
+
 ## Build Status
 The current status of the mpiFileUtils master branch is [![Build Status](https://travis-ci.org/hpc/mpifileutils.png?branch=master)](https://travis-ci.org/hpc/mpifileutils).

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ We welcome contributions to the project.  For details on how to help, see our [C
 
 Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
   Produced at the Lawrence Livermore National Laboratory
-  Written by Adam Moody <moody20@llnl.gov>.
   CODE-673838
 
 Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.

--- a/experimental/dfind/common.h
+++ b/experimental/dfind/common.h
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #ifndef _COMMON_H
 #define _COMMON_H
 

--- a/experimental/dfind/dfind.c
+++ b/experimental/dfind/dfind.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/experimental/dfind/handle.c
+++ b/experimental/dfind/handle.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include <stdio.h>
 #include <sys/types.h>
 #include <string.h>

--- a/experimental/dfind/handle.h
+++ b/experimental/dfind/handle.h
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #ifndef _HANDLE_H
 #define _HANDLE_H
 

--- a/experimental/dfind/pred.c
+++ b/experimental/dfind/pred.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/experimental/dfind/pred.h
+++ b/experimental/dfind/pred.h
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #ifndef _PRED_H
 #define _PRED_H
 

--- a/experimental/dfind/queue.c
+++ b/experimental/dfind/queue.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <libcircle.h>

--- a/experimental/dfind/queue.h
+++ b/experimental/dfind/queue.h
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #ifndef _QUEUE_H
 #define _QUEUE_H
 

--- a/experimental/dgrep/dgrep.c
+++ b/experimental/dgrep/dgrep.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/experimental/dgrep/dgrep.h
+++ b/experimental/dgrep/dgrep.h
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #ifndef DGREP_H
 #define DGREP_H
 

--- a/experimental/dgrep/log.h
+++ b/experimental/dgrep/log.h
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #ifndef LOG_H
 #define LOG_H
 

--- a/experimental/dparallel/dparallel.c
+++ b/experimental/dparallel/dparallel.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include <stdlib.h>
 
 #include "dparallel.h"

--- a/experimental/dparallel/dparallel.h
+++ b/experimental/dparallel/dparallel.h
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #ifndef _DPARALLEL_DPARALLEL_H
 #define _DPARALLEL_DPARALLEL_H
 

--- a/experimental/dparallel/log.h
+++ b/experimental/dparallel/log.h
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #ifndef _DPARALLEL_LOG_H
 #define _DPARALLEL_LOG_H
 

--- a/experimental/dsh/dsh.c
+++ b/experimental/dsh/dsh.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include <dirent.h>
 #include <limits.h>
 #include <stdio.h>

--- a/experimental/dtar/dtar.c
+++ b/experimental/dtar/dtar.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- *
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 /**
  * @file dtar.c - parallel tar main file
  *

--- a/experimental/dtar/mfu_flist_archive.c
+++ b/experimental/dtar/mfu_flist_archive.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- *
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 
 /**
  * @file dtar.c - parallel tar main file

--- a/src/common/mfu.h
+++ b/src/common/mfu.h
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 /* enable C++ codes to include this header directly */
 #ifdef __cplusplus
 extern "C" {

--- a/src/common/mfu_flist.c
+++ b/src/common/mfu_flist.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- *
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #define _GNU_SOURCE
 #ifndef __G_MACROS_H__
 #define __G_MACROS_H__

--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- *
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 /* defines utility functions like memory allocation
  * and error / abort routines */
 

--- a/src/common/mfu_flist_chunk.c
+++ b/src/common/mfu_flist_chunk.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- *
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include <stdio.h>
 #include <stdint.h>
 #include <unistd.h>

--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- *
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #define _GNU_SOURCE
 #ifndef __G_MACROS_H__
 #define __G_MACROS_H__

--- a/src/common/mfu_flist_create.c
+++ b/src/common/mfu_flist_create.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- *
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include <string.h>
 #include <errno.h>
 

--- a/src/common/mfu_flist_internal.h
+++ b/src/common/mfu_flist_internal.h
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- *
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 /* defines internal types and function prototypes for mfu_flist
  * implementations */
 

--- a/src/common/mfu_flist_io.c
+++ b/src/common/mfu_flist_io.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- *
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 /* Implements functions to read/write an flist from/to a file */
 
 #define _GNU_SOURCE

--- a/src/common/mfu_flist_remove.c
+++ b/src/common/mfu_flist_remove.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include <dirent.h>
 #include <limits.h>
 #include <stdio.h>

--- a/src/common/mfu_flist_sort.c
+++ b/src/common/mfu_flist_sort.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include <dirent.h>
 #include <limits.h>
 #include <stdio.h>

--- a/src/common/mfu_flist_usrgrp.c
+++ b/src/common/mfu_flist_usrgrp.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- *
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 /* Implements logic to deal with translation between user id / username and group id / groupname */
 
 #define _GNU_SOURCE

--- a/src/common/mfu_flist_walk.c
+++ b/src/common/mfu_flist_walk.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- *
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 /* Implements logic to walk directories to build an flist */
 
 #define _GNU_SOURCE

--- a/src/common/mfu_io.c
+++ b/src/common/mfu_io.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include "mfu.h"
 
 #include <stdio.h>

--- a/src/common/mfu_io.h
+++ b/src/common/mfu_io.h
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 /* defines reliable I/O functions */
 
 /* enable C++ codes to include this header directly */

--- a/src/common/mfu_param_path.c
+++ b/src/common/mfu_param_path.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include "mfu.h"
 #include "mpi.h"
 

--- a/src/common/mfu_param_path.h
+++ b/src/common/mfu_param_path.h
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 /* defines utility functions like memory allocation
  * and error / abort routines */
 

--- a/src/common/mfu_path.c
+++ b/src/common/mfu_path.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 /* Defines a double linked list representing a file path. */
 
 #include "mfu.h"

--- a/src/common/mfu_path.h
+++ b/src/common/mfu_path.h
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #ifndef MFU_PATH_H
 #define MFU_PATH_H
 

--- a/src/common/mfu_util.c
+++ b/src/common/mfu_util.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include "mfu.h"
 #include "mpi.h"
 #include "dtcmp.h"

--- a/src/common/mfu_util.h
+++ b/src/common/mfu_util.h
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 /* defines utility functions like memory allocation
  * and error / abort routines */
 

--- a/src/dchmod/dchmod.c
+++ b/src/dchmod/dchmod.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- *
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include <dirent.h>
 #include <limits.h>
 #include <stdio.h>

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   Written by Adam Moody <moody20@llnl.gov>.
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
 #include <stdio.h>
 #include <unistd.h>
 #include <getopt.h>

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include <stdio.h>
 #include <getopt.h>
 #include <string.h>

--- a/src/dcp1/cleanup.c
+++ b/src/dcp1/cleanup.c
@@ -1,24 +1,4 @@
 /*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
-/*
  * This file contains the logic to truncate the the destination as well as
  * preserve permissions and ownership. Since it would be redundant, we only
  * pay attention to the first chunk of each file and pass the rest along.

--- a/src/dcp1/cleanup.h
+++ b/src/dcp1/cleanup.h
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 /* See the file "COPYING" for the full license governing this code. */
 
 #ifndef __DCP_CLEANUP_H

--- a/src/dcp1/common.c
+++ b/src/dcp1/common.c
@@ -1,25 +1,5 @@
 /* See the file "COPYING" for the full license governing this code. */
 
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include "common.h"
 #include "handle_args.h"
 

--- a/src/dcp1/common.h
+++ b/src/dcp1/common.h
@@ -1,25 +1,5 @@
 /* See the file "COPYING" for the full license governing this code. */
 
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #ifndef __COMMON_H_
 #define __COMMON_H_
 

--- a/src/dcp1/compare.c
+++ b/src/dcp1/compare.c
@@ -1,25 +1,5 @@
 /* See the file "COPYING" for the full license governing this code. */
 
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include "compare.h"
 #include "dcp1.h"
 

--- a/src/dcp1/compare.h
+++ b/src/dcp1/compare.h
@@ -1,25 +1,5 @@
 /* See the file "COPYING" for the full license governing this code. */
 
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #ifndef __DCP_COMPARE_H
 #define __DCP_COMPARE_H
 

--- a/src/dcp1/copy.c
+++ b/src/dcp1/copy.c
@@ -1,25 +1,5 @@
 /* See the file "COPYING" for the full license governing this code. */
 
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include "copy.h"
 #include "treewalk.h"
 #include "dcp1.h"

--- a/src/dcp1/copy.h
+++ b/src/dcp1/copy.h
@@ -1,25 +1,5 @@
 /* See the file "COPYING" for the full license governing this code. */
 
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #ifndef __DCP_COPY_H
 #define __DCP_COPY_H
 

--- a/src/dcp1/dcp1.c
+++ b/src/dcp1/dcp1.c
@@ -1,25 +1,5 @@
 /* See the file "COPYING" for the full license governing this code. */
 
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include "dcp1.h"
 
 #include "handle_args.h"

--- a/src/dcp1/dcp1.h
+++ b/src/dcp1/dcp1.h
@@ -1,25 +1,5 @@
 /* See the file "COPYING" for the full license governing this code. */
 
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #ifndef __DCP_H_
 #define __DCP_H_
 

--- a/src/dcp1/handle_args.c
+++ b/src/dcp1/handle_args.c
@@ -1,26 +1,6 @@
 /* See the file "COPYING" for the full license governing this code. */
 
 /*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
-/*
  * For an overview of how argument handling was originally designed in dcp,
  * please see the blog post at:
  *

--- a/src/dcp1/handle_args.h
+++ b/src/dcp1/handle_args.h
@@ -1,25 +1,5 @@
 /* See the file "COPYING" for the full license governing this code. */
 
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #ifndef __DCOPY_HANDLE_ARGS_H
 #define __DCOPY_HANDLE_ARGS_H
 

--- a/src/dcp1/treewalk.c
+++ b/src/dcp1/treewalk.c
@@ -1,26 +1,6 @@
 /* See the file "COPYING" for the full license governing this code. */
 
 /*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
-/*
  * This file contains the logic to walk all of the source objects and place
  * them on the queue.
  *

--- a/src/dcp1/treewalk.h
+++ b/src/dcp1/treewalk.h
@@ -1,25 +1,5 @@
 /* See the file "COPYING" for the full license governing this code. */
 
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #ifndef __DCP_TREEWALK_H
 #define __DCP_TREEWALK_H
 

--- a/src/ddup/ddup.c
+++ b/src/ddup/ddup.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   Written by Adam Moody <moody20@llnl.gov>.
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2016, DataDirect Networks, Inc.
- *
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
 #include <stdio.h>
 #include <string.h>
 #include <getopt.h>

--- a/src/dfilemaker/dfilemaker.c
+++ b/src/dfilemaker/dfilemaker.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/drm/drm.c
+++ b/src/drm/drm.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include <dirent.h>
 #include <limits.h>
 #include <stdio.h>

--- a/src/dstripe/dstripe.c
+++ b/src/dstripe/dstripe.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 // mpicc -g -O0 -o restripe restripe.c -llustreapi
 
 #include "config.h"

--- a/src/dwalk/dwalk.c
+++ b/src/dwalk/dwalk.c
@@ -1,23 +1,3 @@
-/*
- * Copyright (c) 2013-2015, Lawrence Livermore National Security, LLC.
- *   Produced at the Lawrence Livermore National Laboratory
- *   CODE-673838
- *
- * Copyright (c) 2006-2007,2011-2015, Los Alamos National Security, LLC.
- *   (LA-CC-06-077, LA-CC-10-066, LA-CC-14-046)
- *
- * Copyright (2013-2015) UT-Battelle, LLC under Contract No.
- *   DE-AC05-00OR22725 with the Department of Energy.
- *
- * Copyright (c) 2015, DataDirect Networks, Inc.
- * 
- * All rights reserved.
- *
- * This file is part of mpiFileUtils.
- * For details, see https://github.com/hpc/fileutils.
- * Please also read the LICENSE file.
-*/
-
 #include <dirent.h>
 #include <limits.h>
 #include <stdio.h>


### PR DESCRIPTION
I've cleaned up the license, notice, and copyright information.

1. The license file is now just the BSD-3 clause
2. The additional "notice" information has been moved to a NOTICE file
3. The copyright statements were added to the readme.