### PR TITLE
dcmp lite mode

### DIFF
--- a/doc/rst/dcmp.1.rst
+++ b/doc/rst/dcmp.1.rst
@@ -42,6 +42,14 @@ OPTIONS
    command. Files walked, started, completed, seconds, files, bytes
    read, byte rate, and file rate.
 
+.. option:: -l, --lite
+
+  lite mode does a comparison of file modification time and size. If
+  modification time and size are the same, then the contents are assumed
+  to be the same. Similarly, if the modification time or size is different,
+  then the contents are assumed to be different. The lite mode does no comparison
+  of data/content in the file.
+
 .. option:: -h, --help
 
    Print the command usage, and the list of options available.


### PR DESCRIPTION
Add option to dcmp to allow comparison of only metadata. If metadata
is the same, then contents are assumed to be the same. Similarly,
if the metadata is different, the contents are assumed to be
different. The lite mode does no comparison of data/content.