### PR TITLE
Fix dwalk default output

### DIFF
--- a/src/common/mfu_flist.c
+++ b/src/common/mfu_flist.c
@@ -1729,7 +1729,7 @@ void mfu_flist_print_summary(mfu_flist flist)
     MPI_Allreduce(&total_bytes,   &all_bytes,   1, MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
 
     /* convert total size to units */
-    if (mfu_debug_level >= MFU_LOG_VERBOSE && rank == 0) {
+    if (rank == 0) {
         MFU_LOG(MFU_LOG_INFO, "Items: %llu", (unsigned long long) all_count);
         MFU_LOG(MFU_LOG_INFO, "  Directories: %llu", (unsigned long long) all_dirs);
         MFU_LOG(MFU_LOG_INFO, "  Files: %llu", (unsigned long long) all_files);

--- a/src/common/mfu_flist_walk.c
+++ b/src/common/mfu_flist_walk.c
@@ -790,9 +790,6 @@ void mfu_flist_walk_paths(uint64_t num_paths, const char** paths, int use_stat, 
               );
     }
 
-    /* print statistics about flist */
-    mfu_flist_print_summary(bflist);
-
     /* hold procs here until summary is printed */
     MPI_Barrier(MPI_COMM_WORLD);
 

--- a/src/dwalk/dwalk.c
+++ b/src/dwalk/dwalk.c
@@ -289,6 +289,9 @@ int main(int argc, char** argv)
     int text = 0;
     struct distribute_option option;
 
+    /* set debug level to MFU_LOG_INFO since it defaults to ERROR */
+    mfu_debug_level = MFU_LOG_INFO;
+
     int option_index = 0;
     static struct option long_options[] = {
         {"input",        1, 0, 'i'},
@@ -498,7 +501,7 @@ int main(int argc, char** argv)
         mfu_flist_print(flist);
     }
 
-    /* print summary about all files */
+    /* print summary statistics of flist */
     mfu_flist_print_summary(flist);
 
     /* print distribution if user specified this option */


### PR DESCRIPTION
dwalk should have been printing the summary to the screen by default.
The reason it was only happening when verbose was set was because
there were a couple of bugs in the mfu_flist_print_summary function.
MFU_LOG_INFO was not set by default, and it was requiring VERBOSE to
be set in order to use MFU_LOG_INFO log/print statements. So
mfu_flist_print_summary would print nothing unless the debug level
was set to VERBOSE. Also, mfu_flist_print_summary does not need
to be called in dwalk.c, because it is already called in mfu_flist_walk.