### PR TITLE
Batchcopy

### DIFF
--- a/doc/rst/dsync.1.rst
+++ b/doc/rst/dsync.1.rst
@@ -22,6 +22,10 @@ OPTIONS
 
    Show differences without changing anything.
 
+.. option:: -b, --batch-files N
+
+   Batch files into groups of up to size N during copy operation.
+
 .. option:: -c, --contents
 
    Compare files byte-by-byte rather than checking size and mtime

--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -426,6 +426,13 @@ int mfu_flist_sort(const char* fields, mfu_flist* flist);
  * Functions to create / remove data on file system based on input list
  ****************************************/
 
+/* allocate a new mfu_copy_opts structure,
+ * and set its fields with default values */
+mfu_copy_opts_t* mfu_copy_opts_new(void);
+
+/* free object allocated in mfu_copy_opts_new */
+void mfu_copy_opts_delete(mfu_copy_opts_t** opts);
+
 /* copy items in list from source paths to destination,
  * each item in source list must come from one of the
  * given source paths, returns 0 on success -1 on error */

--- a/src/common/mfu_flist_chunk.c
+++ b/src/common/mfu_flist_chunk.c
@@ -442,6 +442,11 @@ void mfu_file_chunk_list_lor(mfu_flist list, const mfu_file_chunk* head, const i
     /* get the largest filename */
     uint64_t max_name = mfu_flist_file_max_name(list);
 
+    /* if list is empty, we can't do much */
+    if (max_name == 0) {
+        return;
+    }
+
     /* get a count of how many items are the chunk list */
     uint64_t list_count = mfu_file_chunk_list_size(head);
 
@@ -453,8 +458,8 @@ void mfu_file_chunk_list_lor(mfu_flist list, const mfu_file_chunk* head, const i
     int* ltr = (int*) MFU_MALLOC(list_count * sizeof(int));
 
     /* create type and comparison operation for file names for the segmented scan */
-    MPI_Datatype keytype;
-    DTCMP_Op keyop;
+    MPI_Datatype keytype = MPI_DATATYPE_NULL;
+    DTCMP_Op keyop = DTCMP_OP_NULL;
     DTCMP_Str_create_ascend((int)max_name, &keytype, &keyop);
 
     /* execute segmented scan of comparison flags across file names */

--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -879,7 +879,7 @@ static int mfu_create_link(mfu_flist list, uint64_t idx,
     }
 
     /* ensure that string ends with NUL */
-    path[rc] = '\0';
+    path[readlink_rc] = '\0';
 
     /* create new link */
     int symlink_rc = mfu_symlink(path, dest_path);
@@ -2056,7 +2056,7 @@ int mfu_flist_copy(mfu_flist src_cp_list, int numpaths,
                 MFU_LOG(MFU_LOG_INFO, "Rate: %.3lf %s " \
                     "(%.3" PRId64 " bytes in %.3lf seconds)", \
                     agg_rate_tmp, agg_rate_units, agg_copied, rel_time);
-                MFU_LOG(MFU_LOG_INFO, "Copied %" PRId64 " of %" PRId64 " items (%.3lf%%)", agg_items, src_size, (double)agg_items/(double)src_size*100.0);
+                MFU_LOG(MFU_LOG_INFO, "Copied %" PRId64 " of %" PRId64 " items (%.3lf%%)", batch_offset, src_size, (double)batch_offset/(double)src_size*100.0);
             }
         }
 

--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -2199,3 +2199,60 @@ int mfu_flist_file_sync_meta(mfu_flist src_list, uint64_t src_index, mfu_flist d
 
     return rc;
 }
+
+/* return a newly allocated copy_opts structure, set default values on its fields */
+mfu_copy_opts_t* mfu_copy_opts_new(void)
+{
+    mfu_copy_opts_t* opts = (mfu_copy_opts_t*) MFU_MALLOC(sizeof(mfu_copy_opts_t));
+
+    /* By default, assume we are not copying into a directory */
+    opts->copy_into_dir = 0;
+
+    /* By default, we want the sync option off */
+    opts->do_sync       = 0;
+
+    /* to record destination path that we'll be copying to */
+    opts->dest_path     = NULL;
+
+    /* records name of input file to read source list from (not used?) */
+    opts->input_file    = NULL;
+
+    /* By default, don't bother to preserve all attributes. */
+    opts->preserve      = false;
+
+    /* By default, don't use O_DIRECT. */
+    opts->synchronous   = false;
+
+    /* By default, don't use sparse file. */
+    opts->sparse        = false;
+
+    /* Set default chunk size */
+    opts->chunk_size    = 1*1024*1024;
+
+    /* temporaries used during the copy operation for buffers to read/write data */
+    opts->block_size    = FD_BLOCK_SIZE;
+    opts->block_buf1    = NULL;
+    opts->block_buf2    = NULL;
+
+    /* Lustre grouplock ID */
+    opts->grouplock_id  = -1;
+
+    return opts;
+}
+
+void mfu_copy_opts_delete(mfu_copy_opts_t** popts)
+{
+  if (popts != NULL) {
+    mfu_copy_opts_t* opts = *popts;
+
+    /* free fields allocated on opts */
+    if (opts != NULL) {
+      mfu_free(&opts->dest_path);
+      mfu_free(&opts->input_file);
+      mfu_free(&opts->block_buf1);
+      mfu_free(&opts->block_buf2);
+    }
+
+    mfu_free(popts);
+  }
+}

--- a/src/common/mfu_param_path.h
+++ b/src/common/mfu_param_path.h
@@ -93,6 +93,7 @@ typedef struct {
     char*  block_buf1;    /* buffer to read / write data */
     char*  block_buf2;    /* another buffer to read / write data */
     int    grouplock_id;  /* Lustre grouplock ID */
+    uint64_t batch_files; /* max batch size to copy files, 0 implies no limit */
 } mfu_copy_opts_t;
 
 /* Given a source item name, determine which source path this item

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -75,8 +75,7 @@ void print_usage(void)
     fflush(stdout);
 }
 
-int main(int argc, \
-         char** argv)
+int main(int argc, char** argv)
 {
     /* assume we'll exit with success */
     int rc = 0;
@@ -90,35 +89,15 @@ int main(int argc, \
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
     /* pointer to mfu_copy opts */
-    mfu_copy_opts_t mfu_cp_opts;
-    mfu_copy_opts_t* mfu_copy_opts = &mfu_cp_opts;
+    mfu_copy_opts_t* mfu_copy_opts = mfu_copy_opts_new();
 
     /* By default, show info log messages. */
     /* we back off a level on CIRCLE verbosity since its INFO is verbose */
     CIRCLE_loglevel CIRCLE_debug = CIRCLE_LOG_WARN;
     mfu_debug_level = MFU_LOG_INFO;
 
-    /* Set default chunk size */
-    uint64_t chunk_size = (1*1024*1024);
-    mfu_copy_opts->chunk_size = chunk_size ;
-
     /* By default, don't have iput file. */
     char* inputname = NULL;
-
-    /* By default, don't bother to preserve all attributes. */
-    mfu_copy_opts->preserve = 0;
-
-    /* Lustre grouplock ID */
-    mfu_copy_opts->grouplock_id;
-
-    /* By default, don't use O_DIRECT. */
-    mfu_copy_opts->synchronous = 0;
-
-    /* By default, don't use sparse file. */
-    mfu_copy_opts->sparse = false;
-
-    /* By default, we want the sync option off */
-    mfu_copy_opts->do_sync = 0;
 
     int option_index = 0;
     static struct option long_options[] = {
@@ -335,6 +314,9 @@ int main(int argc, \
 
     /* free the input file name */
     mfu_free(&inputname);
+
+    /* free the copy options */
+    mfu_copy_opts_delete(&mfu_copy_opts);
 
     /* shut down MPI */
     mfu_finalize();

--- a/src/dsync/dsync.c
+++ b/src/dsync/dsync.c
@@ -47,11 +47,12 @@ static void print_usage(void)
     printf("Usage: dsync [options] source target\n");
     printf("\n");
     printf("Options:\n");
-    printf("      --dryrun     - show differences, but do not synchronize files\n");
-    printf("  -c, --contents   - read and compare file contents rather than compare size and mtime\n");
-    printf("  -N, --no-delete  - don't delete extraneous files from target\n");
-    printf("  -v, --verbose    - verbose output\n");
-    printf("  -h, --help       - print usage\n");
+    printf("      --dryrun          - show differences, but do not synchronize files\n");
+    printf("  -b  --batch-files <N> - batch files into groups of N during copy\n");
+    printf("  -c, --contents        - read and compare file contents rather than compare size and mtime\n");
+    printf("  -N, --no-delete       - don't delete extraneous files from target\n");
+    printf("  -v, --verbose         - verbose output\n");
+    printf("  -h, --help            - print usage\n");
     printf("\n");
     fflush(stdout);
 }
@@ -2160,13 +2161,14 @@ int main(int argc, char **argv)
 
     int option_index = 0;
     static struct option long_options[] = {
-        {"contents",  0, 0, 'c'},
-        {"dryrun",    0, 0, 'n'},
-        {"no-delete", 0, 0, 'N'},
-        {"output",    1, 0, 'o'},
-        {"debug",     0, 0, 'd'},
-        {"verbose",   0, 0, 'v'},
-        {"help",      0, 0, 'h'},
+        {"batch-files",  1, 0, 'b'},
+        {"contents",     0, 0, 'c'},
+        {"dryrun",       0, 0, 'n'},
+        {"no-delete",    0, 0, 'N'},
+        {"output",       1, 0, 'o'},
+        {"debug",        0, 0, 'd'},
+        {"verbose",      0, 0, 'v'},
+        {"help",         0, 0, 'h'},
         {0, 0, 0, 0}
     };
     int ret = 0;
@@ -2177,7 +2179,7 @@ int main(int argc, char **argv)
     int help  = 0;
     while (1) {
         int c = getopt_long(
-            argc, argv, "cNo:dvh",
+            argc, argv, "b:cNo:dvh",
             long_options, &option_index
         );
 
@@ -2186,6 +2188,9 @@ int main(int argc, char **argv)
         }
 
         switch (c) {
+        case 'b':
+            mfu_copy_opts->batch_files = atoi(optarg);
+            break;
         case 'c':
             options.contents++;
             break;

--- a/src/dsync/dsync.c
+++ b/src/dsync/dsync.c
@@ -2135,8 +2135,7 @@ int main(int argc, char **argv)
     MPI_Comm_size(MPI_COMM_WORLD, &ranks);
 
     /* pointer to mfu_copy opts */
-    mfu_copy_opts_t mfu_cp_opts;
-    mfu_copy_opts_t* mfu_copy_opts = &mfu_cp_opts;
+    mfu_copy_opts_t* mfu_copy_opts = mfu_copy_opts_new();
 
     /* TODO: allow user to specify file lists as input files */
 
@@ -2155,19 +2154,6 @@ int main(int argc, char **argv)
 
     /* By default, sync option will preserve all attributes. */
     mfu_copy_opts->preserve = true;
-
-    /* By default, don't use O_DIRECT. */
-    mfu_copy_opts->synchronous = false;
-
-    /* By default, don't use sparse file. */
-    mfu_copy_opts->sparse = false;
-
-    /* Set default chunk size */
-    uint64_t chunk_size = (1*1024*1024);
-    mfu_copy_opts->chunk_size = chunk_size;
-
-    /* By default, don't have iput file. */
-    mfu_copy_opts->input_file = NULL;
 
     /* flag to check for sync option */
     mfu_copy_opts->do_sync = 1;
@@ -2354,6 +2340,9 @@ int main(int argc, char **argv)
 
     /* free memory allocated to hold params */
     mfu_free(&paths);
+
+    /* free the copy options structure */
+    mfu_copy_opts_delete(&mfu_copy_opts);
 
     dsync_option_fini();
 


### PR DESCRIPTION
- fix for INVALID_DATATYPE due to DTCMP call in chunk_list_lor with empty list
- fix bug preventing copying of symlinks
- adds functions for allocating and deleting copy_opts structures, sets default values in allocated object
- extends flist_copy to operate in batches of files of specified size, useful in dsync to act as a type of checkpoint in dsync
- adds new --batch-files option to dsync