### PR TITLE
drm: Add remove file capability during walk

### DIFF
--- a/experimental/dtar/dtar.c
+++ b/experimental/dtar/dtar.c
@@ -95,6 +95,9 @@ int main(int argc, char** argv)
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
 
+    /* pointer to mfu_walk_opts */
+    mfu_walk_opts_t* walk_opts = mfu_walk_opts_new();
+
     int option_index = 0;
     static struct option long_options[] = {
         {"create",    0, 0, 'c'},
@@ -249,7 +252,7 @@ int main(int argc, char** argv)
 
         /* walk path to get stats info on all files */
         mfu_flist flist = mfu_flist_new();
-        mfu_flist_walk_param_paths(num_src_params, src_params, 1, 0, flist);
+        mfu_flist_walk_param_paths(num_src_params, src_params, walk_opts, flist);
 
         /* create the archive file */
         mfu_flist_archive_create(flist, opts_tarfile, &archive_opts);
@@ -305,6 +308,9 @@ int main(int argc, char** argv)
             DTAR_exit(EXIT_FAILURE);
         }
     }
+
+    /* free the walk options */
+    mfu_walk_opts_delete(&walk_opts);
 
     /* free context */
     mfu_free(&opts_tarfile);

--- a/src/common/mfu_flist.c
+++ b/src/common/mfu_flist.c
@@ -50,6 +50,31 @@
 #include <sys/ioctl.h>
 #endif
 
+/* return a newly allocated walk_opts structure, set default values on its fields */
+mfu_walk_opts_t* mfu_walk_opts_new(void)
+{
+    mfu_walk_opts_t* opts = (mfu_walk_opts_t*)MFU_MALLOC(sizeof(mfu_walk_opts_t));
+
+    /* Don't set permissions on walk by default */
+    opts->dir_perms = 0;
+
+    /* Remove files in walk by default */
+    opts->remove = 0;
+
+    /* Don't stat files in walk by default */
+    opts->use_stat = 1;
+
+    return opts;
+}
+
+void mfu_walk_opts_delete(mfu_walk_opts_t** popts)
+{
+  if (popts != NULL) {
+    mfu_walk_opts_t* opts = *popts;
+    mfu_free(popts);
+  }
+}
+
 /****************************************
  * Functions on types
  ***************************************/

--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -144,7 +144,7 @@ int mfu_perms_parse(const char* modestr, mfu_perms** pperms);
  * execute for the "all" bits as well because those can also turn on the user's
  * read and execute bits, sets dir_perms to 1 if "rx" should be set on directories
  * and set to 0 otherwise */
-void mfu_perms_need_dir_rx(const mfu_perms* head, int* dir_perms);
+void mfu_perms_need_dir_rx(const mfu_perms* head, mfu_walk_opts_t* walk_opts);
 
 /* free the permissions linked list allocated in mfu_perms_parse,
  * sets pointer to NULL on return */
@@ -169,27 +169,24 @@ void mfu_flist_free(mfu_flist* flist);
  * set directory permission bits in order to walk into a directory,
  * whose permission bits are otherwise restrictive (e.g., useful for recursive unlink) */
 void mfu_flist_walk_path(
-    const char* path,    /* IN  - path to be walked */
-    int use_stat,        /* IN  - whether to stat each item (1) or not (0) */
-    int dir_permissions, /* IN  - whether to set directory permission bits (1) or not (0) during walk */
-    mfu_flist flist      /* OUT - flist to insert walked items into */
+    const char* path,           /* IN  - path to be walked */
+    mfu_walk_opts_t* walk_opts, /* IN  - functions to perform during the walk */
+    mfu_flist flist             /* OUT - flist to insert walked items into */
 );
 
 /* create file list by walking list of directories */
 void mfu_flist_walk_paths(
-    uint64_t num_paths,  /* IN  - number of paths in array */
-    const char** paths,  /* IN  - array of paths to be walkted */
-    int use_stat,        /* IN  - whether to stat each item (1) or not (0) */
-    int dir_permissions, /* IN  - whether to set directory permission bits (1) or not (0) during walk */
-    mfu_flist flist      /* OUT - flist to insert walked items into */
+    uint64_t num_paths,         /* IN  - number of paths in array */
+    const char** paths,         /* IN  - array of paths to be walkted */
+    mfu_walk_opts_t* walk_opts, /* IN  - functions to perform during the walk */
+    mfu_flist flist             /* OUT - flist to insert walked items into */
 );
 
 /* given a list of param_paths, walk each one and add to flist */
 void mfu_flist_walk_param_paths(
     uint64_t num,                 /* IN  - number of paths in array */
     const mfu_param_path* params, /* IN  - array of paths to be walkted */
-    int use_stat,                 /* IN  - whether to stat each item (1) or not (0) */
-    int dir_perms,                /* IN  - whether to set directory permission bits (1) or not (0) during walk */
+    mfu_walk_opts_t* walk_opts,   /* IN  - functions to perform during the walk */
     mfu_flist flist               /* OUT - flist to insert walked items into */
 );
 
@@ -443,6 +440,13 @@ int mfu_flist_copy(
     const mfu_param_path* destpath, /* IN - destination path */
     mfu_copy_opts_t* mfu_copy_opts  /* IN - options to be used during copy */
 );
+
+/* allocate a new mfu_walk_opts structure,
+ * and set its fields with default values */
+mfu_walk_opts_t* mfu_walk_opts_new(void);
+
+/* free object allocated in mfu_walk_opts_new */
+void mfu_walk_opts_delete(mfu_walk_opts_t** opts);
 
 /* create all directories in flist */
 void mfu_flist_mkdir(mfu_flist flist);

--- a/src/common/mfu_flist_chmod.c
+++ b/src/common/mfu_flist_chmod.c
@@ -399,11 +399,11 @@ int mfu_perms_parse(const char* modestr, mfu_perms** p_head)
  * directories during the walk in this case. Also, check for turning on read and
  * execute for the "all" bits as well because those can also turn on the user's
  * read and execute bits */
-void mfu_perms_need_dir_rx(const mfu_perms* head, int* dir_perms)
+void mfu_perms_need_dir_rx(const mfu_perms* head, mfu_walk_opts_t* walk_opts)
 {
     /* flag to check if the usr read & execute bits are being turned on,
      * assume they are not */
-    *dir_perms = 0;
+    walk_opts->dir_perms = 0;
 
     /* extra flags to check if usr read and execute are being turned on */
     int usr_r = 0;
@@ -457,7 +457,7 @@ void mfu_perms_need_dir_rx(const mfu_perms* head, int* dir_perms)
 
     /* only set the dir_perms flag if both the user execute and user read flags are on */
     if (usr_r && usr_x) {
-        *dir_perms = 1;
+        walk_opts->dir_perms = 1;
     }
 
     return;

--- a/src/common/mfu_param_path.h
+++ b/src/common/mfu_param_path.h
@@ -79,7 +79,14 @@ void mfu_param_path_check_copy(
     int* flag_copy_into_dir         /* OUT - flag indicating whether source items should be copied into destination directory (1) or not (0) */
 );
 
-/* options passed to mfu_flist_copy that affect how a copy is executed */
+/* options passed to walk that effect how the walk is executed */
+typedef struct {
+    int    dir_perms;    /* flag option to update dir perms during walk */
+    int    remove;       /* flag option to remove files during walk */
+    int    use_stat;     /* flag option on whether or not to stat files during walk */
+} mfu_walk_opts_t;
+
+/* options passed to mfu_ */
 typedef struct {
     int    copy_into_dir; /* flag indicating whether copying into existing dir */
     int    do_sync;       /* flag option to sync src dir with dest dir */ 

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -1958,6 +1958,9 @@ int main(int argc, char **argv)
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &ranks);
     
+    /* pointer to mfu_walk_opts */
+    mfu_walk_opts_t* walk_opts = mfu_walk_opts_new();
+
     /* TODO: allow user to specify file lists as input files */
 
     /* TODO: three levels of comparison:
@@ -2089,19 +2092,16 @@ int main(int argc, char **argv)
     mfu_flist flist1 = mfu_flist_new();
     mfu_flist flist2 = mfu_flist_new();
            
-    /* walk src and dest paths and fill in file lists */
-    int walk_stat = 1;
-    int dir_perm  = 0;
 
     if (rank == 0) {
         MFU_LOG(MFU_LOG_INFO, "Walking source path");
     }
-    mfu_flist_walk_param_paths(1,  srcpath, walk_stat, dir_perm, flist1);
+    mfu_flist_walk_param_paths(1,  srcpath, walk_opts, flist1);
 
     if (rank == 0) {
         MFU_LOG(MFU_LOG_INFO, "Walking destination path");
     }
-    mfu_flist_walk_param_paths(1, destpath, walk_stat, dir_perm, flist2);
+    mfu_flist_walk_param_paths(1, destpath, walk_opts, flist2);
 
     /* store src and dest path strings */
     const char* path1 = srcpath->path;
@@ -2147,6 +2147,9 @@ int main(int argc, char **argv)
     mfu_free(&paths);
 
     dcmp_option_fini();
+
+    /* free the walk options */
+    mfu_walk_opts_delete(&walk_opts);
 
     /* shut down */
     mfu_finalize();

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -91,6 +91,9 @@ int main(int argc, char** argv)
     /* pointer to mfu_copy opts */
     mfu_copy_opts_t* mfu_copy_opts = mfu_copy_opts_new();
 
+    /* pointer to mfu_walk opts */
+    mfu_walk_opts_t* walk_opts = mfu_walk_opts_new();
+
     /* By default, show info log messages. */
     /* we back off a level on CIRCLE verbosity since its INFO is verbose */
     CIRCLE_loglevel CIRCLE_debug = CIRCLE_LOG_WARN;
@@ -278,11 +281,7 @@ int main(int argc, char** argv)
     mfu_flist flist = mfu_flist_new();
 
     if (inputname == NULL) {
-        /* walk paths and fill in file list */
-        int walk_stat = 1;
-        int dir_perm  = 0;
-
-        mfu_flist_walk_param_paths(numpaths_src, paths, walk_stat, dir_perm, flist);
+        mfu_flist_walk_param_paths(numpaths_src, paths, walk_opts, flist);
     } else {
         struct mfu_flist_skip_args skip_args;
 
@@ -318,6 +317,10 @@ int main(int argc, char** argv)
     /* free the copy options */
     mfu_copy_opts_delete(&mfu_copy_opts);
 
+    /* free the copy options */
+    mfu_walk_opts_delete(&walk_opts);
+
+    /* shut down MPI */
     /* shut down MPI */
     mfu_finalize();
     MPI_Finalize();

--- a/src/ddup/ddup.c
+++ b/src/ddup/ddup.c
@@ -167,6 +167,9 @@ int main(int argc, char** argv)
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &ranks);
 
+    /* pointer to mfu_walk_opts */
+    mfu_walk_opts_t* walk_opts = mfu_walk_opts_new();
+
     mfu_debug_level = MFU_LOG_INFO;
 
     static struct option long_options[] = {
@@ -284,7 +287,7 @@ int main(int argc, char** argv)
     mfu_flist flist = mfu_flist_new();
 
     /* Walk the path(s) to build the flist */
-    mfu_flist_walk_path(dir, 1, 0, flist);
+    mfu_flist_walk_path(dir, walk_opts, flist);
 
     /* TODO: spread list among procs? */
 
@@ -488,6 +491,9 @@ int main(int argc, char** argv)
         MPI_Allreduce(&checking_files, &sum_checking_files, 1,
                       MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
     }
+
+    /* free the walk options */
+    mfu_walk_opts_delete(&walk_opts);
 
     mfu_free(&group_rank);
     mfu_free(&group_ranks);

--- a/src/dfind/dfind.c
+++ b/src/dfind/dfind.c
@@ -13,10 +13,6 @@
 #include "mfu.h"
 #include "common.h"
 
-/* TODO: change globals to struct */
-static int walk_stat = 1;
-static int dir_perm = 0;
-
 int MFU_PRED_EXEC  (mfu_flist flist, uint64_t idx, void* arg);
 int MFU_PRED_PRINT (mfu_flist flist, uint64_t idx, void* arg);
 
@@ -167,6 +163,9 @@ int main (int argc, char** argv)
     int rank, ranks;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &ranks);
+
+    /* pointer to mfu_walk_opts */
+    mfu_walk_opts_t* walk_opts = mfu_walk_opts_new();
 
     /* capture current time for any time based queries,
      * to get a consistent value, capture and bcast from rank 0 */
@@ -452,7 +451,7 @@ int main (int argc, char** argv)
 
     if (walk) {
         /* walk list of input paths */
-        mfu_flist_walk_param_paths(numpaths, paths, walk_stat, dir_perm, flist);
+        mfu_flist_walk_param_paths(numpaths, paths, walk_opts, flist);
     }
     else {
         /* read data from cache file */
@@ -492,6 +491,9 @@ int main (int argc, char** argv)
 
     /* free structure holding current time */
     mfu_free(&now_t);
+
+    /* free the walk options */
+    mfu_walk_opts_delete(&walk_opts);
 
     /* shut down MPI */
     mfu_finalize();

--- a/src/dstripe/dstripe.c
+++ b/src/dstripe/dstripe.c
@@ -311,6 +311,9 @@ int main(int argc, char* argv[])
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &ranks);
 
+    /* pointer to mfu_walk_opts */
+    mfu_walk_opts_t* walk_opts = mfu_walk_opts_new();
+
     uint64_t idx;
     int option_index = 0;
     int usage = 0;
@@ -450,7 +453,7 @@ int main(int argc, char* argv[])
 
     /* walk list of input paths and stat as we walk */
     mfu_flist flist = mfu_flist_new();
-    mfu_flist_walk_param_paths(numpaths, paths, 1, 0, flist);
+    mfu_flist_walk_param_paths(numpaths, paths, walk_opts, flist);
 
     /* filter down our list to files which don't meet our striping requirements */
     mfu_flist filtered = filter_list(flist, stripes, stripe_size, min_size);
@@ -568,6 +571,9 @@ int main(int argc, char* argv[])
 
     /* wait for everyone to finish */
     MPI_Barrier(MPI_COMM_WORLD);
+
+    /* free the walk options */
+    mfu_walk_opts_delete(&walk_opts);
 
     /* free filtered list, path parameters */
     mfu_flist_free(&filtered);

--- a/src/dsync/dsync.c
+++ b/src/dsync/dsync.c
@@ -2135,6 +2135,9 @@ int main(int argc, char **argv)
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &ranks);
 
+    /* pointer to mfu_walk_opts */
+    mfu_walk_opts_t* walk_opts = mfu_walk_opts_new();
+
     /* pointer to mfu_copy opts */
     mfu_copy_opts_t* mfu_copy_opts = mfu_copy_opts_new();
 
@@ -2279,15 +2282,12 @@ int main(int argc, char **argv)
     mfu_flist flist1 = mfu_flist_new();
     mfu_flist flist2 = mfu_flist_new();
            
-    /* walk src and dest paths and fill in file lists */
-    int walk_stat = 1;
-    int dir_perm  = 0;
 
     /* walk source path */
     if (rank == 0) {
         MFU_LOG(MFU_LOG_INFO, "Walking source path");
     }
-    mfu_flist_walk_param_paths(1, srcpath, walk_stat, dir_perm, flist1);
+    mfu_flist_walk_param_paths(1, srcpath, walk_opts, flist1);
 
     /* check that we actually got something so that we don't delete
      * an entire target directory because of a typo on the source dir */
@@ -2307,7 +2307,7 @@ int main(int argc, char **argv)
     if (rank == 0) {
         MFU_LOG(MFU_LOG_INFO, "Walking destination path");
     }
-    mfu_flist_walk_param_paths(1, destpath, walk_stat, dir_perm, flist2);
+    mfu_flist_walk_param_paths(1, destpath, walk_opts, flist2);
 
     /* store src and dest path strings */
     const char* path1 = srcpath->path;
@@ -2350,6 +2350,9 @@ int main(int argc, char **argv)
     mfu_copy_opts_delete(&mfu_copy_opts);
 
     dsync_option_fini();
+
+    /* free the walk options */
+    mfu_walk_opts_delete(&walk_opts);
 
     /* shut down */
     mfu_finalize();


### PR DESCRIPTION
    - Add remove option to drm
    - Add mfu_walk_opts_t struct to hold
      desired functionality during walk
    - Pass walk_opts struct to
      mfu_flist_walk_param_paths instead of
      individual parameters (dir_perms & remove)
    - Delete files in mfu_flist_walk for the
      walk with stat and without
    - Delete directories by level in drm