### PR TITLE
Add support for copying GPFS ACLs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,9 @@ PKG_CHECK_MODULES([libcircle], libcircle)
 # Check for libdtcmp.
 X_AC_DTCMP
 
+# Check for GPFS
+X_AC_GPFS
+
 # Check for Lustre
 X_AC_LUSTRE
 

--- a/m4/lx_find_gpfs.m4
+++ b/m4/lx_find_gpfs.m4
@@ -1,0 +1,39 @@
+dnl #
+dnl # Determines if GPFS API is installed.
+dnl #
+AC_DEFUN([X_AC_GPFS], [
+	AC_ARG_ENABLE(gpfs,
+		AC_HELP_STRING([--enable-gpfs],
+		[enable GPFS/Spectrum Scale support]),
+		[], [enable_gpfs=no])
+
+	AS_CASE(["x$enable_gpfs"],
+		["xcheck"],
+		[gpfs_found="yes"],
+		["xyes"],
+		[gpfs_found="yes"],
+		["xno"],
+		[gpfs_found="no"],
+		[AC_MSG_ERROR([Unknown option $enable_gpfs])])
+
+
+	AS_IF([test "x$enable_gpfs" != "xno"], [
+		AC_CHECK_HEADERS([gpfs.h],
+			[], [gpfs_found="no"], [])
+
+		AS_IF([test "x$gpfs_found" != "xno"], [
+			AC_DEFINE([GPFS_SUPPORT], [1],
+			    [Define to 1 if GPFS can be used])
+			GPFS_LIBS="-lgpfs"
+			AC_SUBST(GPFS_LIBS)
+		])
+	])
+
+	AC_MSG_CHECKING([whether to enable GPFS support])
+	AS_IF([test "x$enable_gpfs" != "xno"], [
+	  AS_IF([test "x$gpfs_found" != "xyes"], [
+		  AC_MSG_ERROR([GPFS libraries are not available.])
+	  ])
+	])
+	AC_MSG_RESULT([$gpfs_found])
+])

--- a/m4/lx_find_gpfs.m4
+++ b/m4/lx_find_gpfs.m4
@@ -2,10 +2,23 @@ dnl #
 dnl # Determines if GPFS API is installed.
 dnl #
 AC_DEFUN([X_AC_GPFS], [
+
+  AC_ARG_WITH([gpfs], [AC_HELP_STRING([--with-gpfs=PATH],
+	  [path to GPFS installion [default=/usr/lpp/mmfs]])], [
+  	GPFS_INCLUDE="${withval}/include"
+	  GPFS_LIB="${withval}/lib"
+	  AC_MSG_RESULT("${withval}")
+  ], [
+    GPFS_INCLUDE="/usr/lpp/mmfs/include"
+    GPFS_LIB="/usr/lpp/mmfs/lib"
+  ])
+
 	AC_ARG_ENABLE(gpfs,
 		AC_HELP_STRING([--enable-gpfs],
 		[enable GPFS/Spectrum Scale support]),
 		[], [enable_gpfs=no])
+
+
 
 	AS_CASE(["x$enable_gpfs"],
 		["xcheck"],
@@ -24,6 +37,9 @@ AC_DEFUN([X_AC_GPFS], [
 		AS_IF([test "x$gpfs_found" != "xno"], [
 			AC_DEFINE([GPFS_SUPPORT], [1],
 			    [Define to 1 if GPFS can be used])
+		  CFLAGS="$CFLAGS -I${GPFS_INCLUDE} ${MPI_CFLAGS}"
+		  CXXFLAGS="$CXXFLAGS -I${GPFS_INCLUDE} ${MPI_CXXFLAGS}"
+			LDFLAGS="$LDFLAGS -L${GPFS_LIB} ${MPI_CLDFLAGS}"
 			GPFS_LIBS="-lgpfs"
 			AC_SUBST(GPFS_LIBS)
 		])
@@ -36,4 +52,9 @@ AC_DEFUN([X_AC_GPFS], [
 	  ])
 	])
 	AC_MSG_RESULT([$gpfs_found])
+	AS_IF([test "x$enable_gpfs" != "xno"], [
+  	AC_SEARCH_LIBS([gpfs_fgetattrs], [gpfs], [], [
+      AC_MSG_ERROR(
+				[couldn't find a suitable GPFS library, use --with-gpfs=PATH])], [])
+  ])
 ])


### PR DESCRIPTION
We were interesting in using mpifileutils for copying data from one GPFS file-system to another however needed ACL support.

This patch adds support to enable `--enable-gpfs` to configure and adds calls to GPFS API `gpfs_getacl` and `gpfs_putacl` into `mfu_copy_permissions`.

Note that I have added include for `config.h` which was previously missing. There are bunch of `#ifdef LUSTRE_SUPPORT` lines already in the code, so adding config.h may have enabled some LUSTRE functionality? (I have no lustre systems to check this).

IBM docs on the API are at https://www.ibm.com/support/knowledgecenter/en/STXKQY_5.0.1/com.ibm.spectrum.scale.v5r01.doc/bl1adm_gpfs_getacl.htm

Code checks that when calling gpfs_getacl, 0 is returned - i.e. valid ACL had been collected, before attempting to write to dest_file. This means reading from a non-gpfs file-system there is no issue as the ACL will fail to read. On writing to a non GPFS file-system a warning will be produced as the ACL cannot be written.

I've done some basic testing of files and directories with both directly placed and inherited ACLs with both dcp and dsync.