### PR TITLE
Set Lustre grouplock ID to zero by default

### DIFF
--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -2276,8 +2276,8 @@ mfu_copy_opts_t* mfu_copy_opts_new(void)
     opts->block_buf1    = NULL;
     opts->block_buf2    = NULL;
 
-    /* Lustre grouplock ID */
-    opts->grouplock_id  = -1;
+    /* Zero is invalid for the Lustre grouplock ID. */
+    opts->grouplock_id  = 0;
 
     /* By default, do not limit the batch size */
     opts->batch_files   = 0;


### PR DESCRIPTION
Setting the Lustre grouplock ID to zero by
default prevents errors when LUSTRE_SUPPORT
is available but NFS is the filesystem being
used.