### PR TITLE
Fix type error when setting preserve option in dcp

### DIFF
--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -187,7 +187,7 @@ int main(int argc, char** argv)
                 }
                 break;
             case 'p':
-                mfu_copy_opts->preserve = 1;
+                mfu_copy_opts->preserve = true;
                 if(rank == 0) {
                     MFU_LOG(MFU_LOG_INFO, "Preserving file attributes.");
                 }


### PR DESCRIPTION
The boolean preserve field from the mfu_copy_opts
struct was being set to an integer (1) in dcp.