### PR TITLE
spack build deps instructions

### DIFF
--- a/doc/rst/build.rst
+++ b/doc/rst/build.rst
@@ -27,4 +27,30 @@ an `install` directory the build commands are thus:
    $ cd build
    $ cmake ../mpifileutils -DWITH_DTCMP_PREFIX=../install -DWITH_LibCircle_PREFIX=../install -DCMAKE_INSTALL_PREFIX=../install
 
-One can also use spack to create an environment.
+One can also use spack to create an environment and view with the provided `spack.yaml` file.
+First, make sure that you've set up spack in your shell (see `these instructions <https://spack.readthedocs.io/en/latest/getting_started.html>`_).
+Next, be sure that your `~/.spack/packages.yaml` is configured to ensure that spack can detect system-provided packages.
+
+From the root directory of mpifileutils, run the command `spack find` to determine which packages spack will install.
+Next, run `spack concretize` to build have spack perform dependency analysis.
+Finally, run `spack install` to build the dependencies.
+
+There are two ways to tell CMake about the dependencies.
+First, you can use `spack load [depname]` to put the installed dependency into your environment paths.
+Then, at configure time, CMake will automatically detect the location of these dependencies.
+Thus, the commands to build become:
+
+.. code-block:: Bash
+
+   $ git clone https://github.com/hpc/mpifileutils
+   $ mkdir build install
+   $ cd mpifileutils
+   $ spack install
+   $ spack load dtcmp
+   $ spack load libcircle
+   $ spack load libarchive
+   $ cd ../build
+   $ cmake ../mpifileutils
+
+The other way to use spack is to create a "view" to the installed dependencies.
+Details on this are coming soon.

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,3 +9,4 @@ spack:
   repos: []
   packages: {}
   config: {}
+#  view: true


### PR DESCRIPTION
Spack views will soon get a feature upgrade, but in the mean time, these are the instructions for building the dependencies.