### PR TITLE
update old dcp1 tests

### DIFF
--- a/test/legacy/dcp1_tests/test_all.sh
+++ b/test/legacy/dcp1_tests/test_all.sh
@@ -9,14 +9,15 @@
 # Turn this on if you want output from each test printed out.
 DEBUG=1
 
-# A temporary directory that all tests can use for scratch files.
-TEST_TMP_DIR=../tmp
+# set environment variables (TEST_TMP_DIR & TEST_DCP_BIN to run tests)
+TEST_TMP_DIR=$1
+TEST_DCP_BIN=$2
 
-# The dcp1 binary path to use. This must be relative to the test_all.sh script.
-TEST_DCP_BIN=../src/dcp1
-
-# The mpirun binary to use.
-TEST_MPIRUN_BIN=/usr/bin/mpirun
+if [ -z $TEST_TMP_DIR ] || [ -z $TEST_DCP_BIN ]; then
+    echo 'Please set TEST_TMP_DIR and TEST_DCP_BIN'
+    echo 'i.e ./test_all.sh /tmp/<username> /path/to/dcp1/install'
+    exit 1
+fi
 
 # The cmp binary to use.
 TEST_CMP_BIN=/usr/bin/cmp
@@ -39,7 +40,7 @@ pushd $TESTS_DIR > /dev/null
 mkdir $TEST_TMP_DIR
 
 echo "# =============================================================================="
-echo "# Running ALL tests for DCP."
+echo "# Running ALL tests for DCP1."
 echo "# =============================================================================="
 echo "# Tests started at: $(date)"
 echo "# =============================================================================="
@@ -47,7 +48,7 @@ echo "# ========================================================================
 # Fix up the tmp and bin paths for subshells.
 export DCP_TEST_BIN=$(readlink -f $TEST_DCP_BIN)
 export DCP_TEST_TMP=$(readlink -f $TEST_TMP_DIR)
-export DCP_MPIRUN_BIN=$(readlink -f $TEST_MPIRUN_BIN)
+#export DCP_MPIRUN_BIN=$(readlink -f $TEST_MPIRUN_BIN)
 export DCP_CMP_BIN=$(readlink -f $TEST_CMP_BIN)
 
 # Tell the tests what mode we're in

--- a/test/legacy/dcp1_tests/test_dcp1_many_dir_to_single_dir/test.sh
+++ b/test/legacy/dcp1_tests/test_dcp1_many_dir_to_single_dir/test.sh
@@ -20,7 +20,6 @@
 
 # Print out the basic paths we'll be using.
 echo "Using dcp1 binary at: $DCP_TEST_BIN"
-echo "Using mpirun binary at: $DCP_MPIRUN_BIN"
 echo "Using tmp directory at: $DCP_TEST_TMP"
 
 ##############################################################################
@@ -59,7 +58,7 @@ dd if=/dev/urandom of=$PATH_G_RANDOM bs=3M count=2
 # Test copying several directories to a directory. The result should be the directories
 # placed inside the directory.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN -R $PATH_A_DIRECTORY $PATH_B_DIRECTORY $PATH_C_DIRECTORY $PATH_D_DIRECTORY
+mpirun -n 3 $DCP_TEST_BIN $PATH_A_DIRECTORY $PATH_B_DIRECTORY $PATH_C_DIRECTORY $PATH_D_DIRECTORY
 if [[ $? -ne 0 ]]; then
     echo "Error returned when copying an several directories to a directory (A,B,C -> D)."
     exit 1;

--- a/test/legacy/dcp1_tests/test_dcp1_many_dir_to_single_file/test.sh
+++ b/test/legacy/dcp1_tests/test_dcp1_many_dir_to_single_file/test.sh
@@ -20,7 +20,6 @@
 
 # Print out the basic paths we'll be using.
 echo "Using dcp1 binary at: $DCP_TEST_BIN"
-echo "Using mpirun binary at: $DCP_MPIRUN_BIN"
 echo "Using tmp directory at: $DCP_TEST_TMP"
 
 ##############################################################################
@@ -62,7 +61,7 @@ mkdir $PATH_G_DIRECTORY
 # Test copying several directories into an empty file. This should result in
 # an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_D_DIRECTORY $PATH_E_DIRECTORY $PATH_F_DIRECTORY $PATH_A_EMPTY
+mpirun -n 3 $DCP_TEST_BIN $PATH_D_DIRECTORY $PATH_E_DIRECTORY $PATH_F_DIRECTORY $PATH_A_EMPTY
 if [[ $? -eq 0 ]]; then
     echo "Unexpected success when copying several directories to an empty file. (D,E,F -> A)."
     exit 1;
@@ -72,7 +71,7 @@ fi
 # Test copying several directories into a random file. This should result in
 # an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_D_DIRECTORY $PATH_E_DIRECTORY $PATH_F_DIRECTORY $PATH_B_RANDOM
+mpirun -n 3 $DCP_TEST_BIN $PATH_D_DIRECTORY $PATH_E_DIRECTORY $PATH_F_DIRECTORY $PATH_B_RANDOM
 if [[ $? -eq 0 ]]; then
     echo "Unexpected success when copying several directories to a random file. (D,E,F -> B)."
     exit 1;
@@ -82,7 +81,7 @@ fi
 # Test copying several directories into a no-exist file. This should result in
 # an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_D_DIRECTORY $PATH_E_DIRECTORY $PATH_F_DIRECTORY $PATH_C_NOEXIST
+mpirun -n 3 $DCP_TEST_BIN $PATH_D_DIRECTORY $PATH_E_DIRECTORY $PATH_F_DIRECTORY $PATH_C_NOEXIST
 if [[ $? -eq 0 ]]; then
     echo "Unexpected success when copying several directories to a no-exist file. (D,E,F -> C)."
     exit 1;

--- a/test/legacy/dcp1_tests/test_dcp1_many_file_to_single_dir/test.sh
+++ b/test/legacy/dcp1_tests/test_dcp1_many_file_to_single_dir/test.sh
@@ -20,7 +20,6 @@
 
 # Print out the basic paths we'll be using.
 echo "Using dcp1 binary at: $DCP_TEST_BIN"
-echo "Using mpirun binary at: $DCP_MPIRUN_BIN"
 echo "Using tmp directory at: $DCP_TEST_TMP"
 
 ##############################################################################
@@ -56,7 +55,7 @@ mkdir $PATH_E_DIRECTORY
 # Test copying several files to a directory. The result should be the files
 # placed inside the directory.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_A_EMPTY $PATH_C_RANDOM $PATH_B_EMPTY $PATH_D_RANDOM $PATH_E_DIRECTORY
+mpirun -n 3 $DCP_TEST_BIN $PATH_A_EMPTY $PATH_C_RANDOM $PATH_B_EMPTY $PATH_D_RANDOM $PATH_E_DIRECTORY
 if [[ $? -ne 0 ]]; then
     echo "Error returned when copying an several files to a directory (A,B,C,D -> E)."
     exit 1;

--- a/test/legacy/dcp1_tests/test_dcp1_many_file_to_single_file/test.sh
+++ b/test/legacy/dcp1_tests/test_dcp1_many_file_to_single_file/test.sh
@@ -20,7 +20,6 @@
 
 # Print out the basic paths we'll be using.
 echo "Using dcp1 binary at: $DCP_TEST_BIN"
-echo "Using mpirun binary at: $DCP_MPIRUN_BIN"
 echo "Using tmp directory at: $DCP_TEST_TMP"
 
 ##############################################################################
@@ -64,7 +63,7 @@ dd if=/dev/urandom of=$PATH_H_RANDOM bs=6M count=2
 # Test copying several empty files into an empty file. This should result in
 # an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_A_EMPTY $PATH_B_EMPTY $PATH_C_EMPTY $PATH_D_EMPTY
+mpirun -n 3 $DCP_TEST_BIN $PATH_A_EMPTY $PATH_B_EMPTY $PATH_C_EMPTY $PATH_D_EMPTY
 if [[ $? -eq 0 ]]; then
     echo "Unexpected success when copying empty files to an empty file. (A,B,C -> D)."
     exit 1;
@@ -74,7 +73,7 @@ fi
 # Test copying several empty files into a random file. This should result in
 # an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_A_EMPTY $PATH_B_EMPTY $PATH_C_EMPTY $PATH_E_EMPTY
+mpirun -n 3 $DCP_TEST_BIN $PATH_A_EMPTY $PATH_B_EMPTY $PATH_C_EMPTY $PATH_E_EMPTY
 if [[ $? -eq 0 ]]; then
     echo "Unexpected success when copying empty files to a random file (A,B,C -> E)."
     exit 1;
@@ -84,7 +83,7 @@ fi
 # Test copying several random files into an empty file. This should result in
 # an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_E_RANDOM $PATH_F_RANDOM $PATH_G_RANDOM $PATH_A_EMPTY
+mpirun -n 3 $DCP_TEST_BIN $PATH_E_RANDOM $PATH_F_RANDOM $PATH_G_RANDOM $PATH_A_EMPTY
 if [[ $? -eq 0 ]]; then
     echo "Unexpected success when copying random files to an empty file (E,F,G -> A)."
     exit 1;
@@ -94,7 +93,7 @@ fi
 # Test copying several random files into a file that doesn't exist. This
 # should result in an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_E_RANDOM $PATH_F_RANDOM $PATH_G_RANDOM $PATH_I_NOEXIST
+mpirun -n 3 $DCP_TEST_BIN $PATH_E_RANDOM $PATH_F_RANDOM $PATH_G_RANDOM $PATH_I_NOEXIST
 if [[ $? -eq 0 ]]; then
     echo "Unexpected success when copying random files to a no-exist file (E,F,G -> I)."
     exit 1;

--- a/test/legacy/dcp1_tests/test_dcp1_single_dir_to_single_dir/test.sh
+++ b/test/legacy/dcp1_tests/test_dcp1_single_dir_to_single_dir/test.sh
@@ -20,7 +20,6 @@
 
 # Print out the basic paths we'll be using.
 echo "Using dcp1 binary at: $DCP_TEST_BIN"
-echo "Using mpirun binary at: $DCP_MPIRUN_BIN"
 echo "Using tmp directory at: $DCP_TEST_TMP"
 
 ##############################################################################
@@ -47,7 +46,7 @@ dd if=/dev/urandom of=$PATH_C_RANDOM bs=3M count=2
 # Test copying a directory to a directory. The result should be the directory
 # placed inside the directory.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN -R $PATH_A_DIRECTORY $PATH_B_DIRECTORY
+mpirun -n 3 $DCP_TEST_BIN $PATH_A_DIRECTORY $PATH_B_DIRECTORY
 if [[ $? -ne 0 ]]; then
     echo "Error returned when copying a directory to a directory (A -> B)."
     exit 1;

--- a/test/legacy/dcp1_tests/test_dcp1_single_dir_to_single_file/test.sh
+++ b/test/legacy/dcp1_tests/test_dcp1_single_dir_to_single_file/test.sh
@@ -20,7 +20,6 @@
 
 # Print out the basic paths we'll be using.
 echo "Using dcp1 binary at: $DCP_TEST_BIN"
-echo "Using mpirun binary at: $DCP_MPIRUN_BIN"
 echo "Using tmp directory at: $DCP_TEST_TMP"
 
 ##############################################################################
@@ -46,7 +45,7 @@ dd if=/dev/urandom of=$PATH_C_RANDOM bs=4M count=5
 ##############################################################################
 # Test copying the directory to an empty file. The result should be an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_A_DIRECTORY $PATH_B_EMPTY
+mpirun -n 3 $DCP_TEST_BIN $PATH_A_DIRECTORY $PATH_B_EMPTY
 if [[ $? -eq 0 ]]; then
     echo "Unexpectedd success when copying a directory to an empty file. (A -> B)."
     exit 1;
@@ -55,7 +54,7 @@ fi
 ##############################################################################
 # Test copying a directory to a random file. The result should be an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_A_DIRECTORY $PATH_C_RANDOM
+mpirun -n 3 $DCP_TEST_BIN $PATH_A_DIRECTORY $PATH_C_RANDOM
 if [[ $? -eq 0 ]]; then
     echo "Unexpected success when copying a directory to a random file (A -> C)."
     exit 1;

--- a/test/legacy/dcp1_tests/test_dcp1_single_file_to_single_dir/test.sh
+++ b/test/legacy/dcp1_tests/test_dcp1_single_file_to_single_dir/test.sh
@@ -20,7 +20,6 @@
 
 # Print out the basic paths we'll be using.
 echo "Using dcp1 binary at: $DCP_TEST_BIN"
-echo "Using mpirun binary at: $DCP_MPIRUN_BIN"
 echo "Using cmp binary at: $DCP_CMP_BIN"
 echo "Using tmp directory at: $DCP_TEST_TMP"
 
@@ -52,7 +51,7 @@ mkdir $PATH_D_DIRECTORY
 ##############################################################################
 # Test copying a no-exist file to a directory. The result should be an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_A_NOEXIST $PATH_D_DIRECTORY
+mpirun -n 3 $DCP_TEST_BIN $PATH_A_NOEXIST $PATH_D_DIRECTORY
 
 if [[ $? -eq 0 ]]; then
     echo "Unexpected success when copying a no-exist file to a directory (A -> D)."
@@ -63,7 +62,7 @@ fi
 # Test copying an empty file to a directory. The result should be the empty
 # file placed inside the directory.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_B_EMPTY $PATH_D_DIRECTORY
+mpirun -n 3 $DCP_TEST_BIN $PATH_B_EMPTY $PATH_D_DIRECTORY
 if [[ $? -ne 0 ]]; then
     echo "Error returned when copying an empty file to a directory (B -> D)."
     exit 1;
@@ -79,7 +78,7 @@ fi
 # Test copying an empty file to a directory. The result should be the empty
 # file placed inside the directory.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_C_RANDOM $PATH_D_DIRECTORY
+mpirun -n 3 $DCP_TEST_BIN $PATH_C_RANDOM $PATH_D_DIRECTORY
 if [[ $? -ne 0 ]]; then
     echo "Error returned when copying a random file to a directory (C -> D)."
     exit 1;

--- a/test/legacy/dcp1_tests/test_dcp1_single_file_to_single_file/test.sh
+++ b/test/legacy/dcp1_tests/test_dcp1_single_file_to_single_file/test.sh
@@ -23,7 +23,6 @@
 
 # Print out the basic paths we'll be using.
 echo "Using dcp1 binary at: $DCP_TEST_BIN"
-echo "Using mpirun binary at: $DCP_MPIRUN_BIN"
 echo "Using cmp binary at: $DCP_CMP_BIN"
 echo "Using tmp directory at: $DCP_TEST_TMP"
 
@@ -61,7 +60,7 @@ stat $PATH_E_RANDOM
 # Test copying an empty file to an empty file. The result should be two files
 # which remain empty with no error output.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_B_EMPTY $PATH_C_EMPTY
+mpirun -n 3 $DCP_TEST_BIN $PATH_B_EMPTY $PATH_C_EMPTY
 
 if [[ $? -ne 0 ]]; then
     echo "Error returned when copying empty file to empty file (B -> C)."
@@ -78,7 +77,7 @@ fi
 # Test copying a random file to an empty file. The result should be two files
 # which both contain the contents of the first random file.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_D_RANDOM $PATH_B_EMPTY
+mpirun -n 3 $DCP_TEST_BIN $PATH_D_RANDOM $PATH_B_EMPTY
 if [[ $? -ne 0 ]]; then
     echo "Error returned when copying random file to empty file (D -> B)."
     exit 1;
@@ -94,7 +93,7 @@ fi
 # Test copying a random file to another random  file. The result should be two
 # files which both contain the contents of the first random file.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_D_RANDOM $PATH_E_RANDOM
+mpirun -n 3 $DCP_TEST_BIN $PATH_D_RANDOM $PATH_E_RANDOM
 if [[ $? -ne 0 ]]; then
     echo "Error returned when copying random file to random file (D -> E)."
     exit 1;


### PR DESCRIPTION
Updated dcp1 tests scripts to use proper arguments for mpirun as
well as dcp1. The scripts were using many arguments that did not
exist anymore or had been changed/updated, which is why the tests
were failing. All tests for dcp1 pass now by running ./test_all
and setting two env variables.