### PR TITLE
make tools verbose by default, and add quiet option

### DIFF
--- a/doc/rst/dchmod.1.rst
+++ b/doc/rst/dchmod.1.rst
@@ -62,6 +62,10 @@ OPTIONS
    directory tree, and the number of files the command operated on, and
    the files/sec rate for each of those.
 
+.. option:: -q, --quiet
+
+   Run tool silently. No output is printed.
+
 .. option:: -h, --help
 
    Print the command usage, and the list of options available.

--- a/doc/rst/dcmp.1.rst
+++ b/doc/rst/dcmp.1.rst
@@ -42,6 +42,10 @@ OPTIONS
    command. Files walked, started, completed, seconds, files, bytes
    read, byte rate, and file rate.
 
+.. option:: -q, --quiet
+
+   Run tool silently. No output is printed.
+
 .. option:: -l, --lite
 
   lite mode does a comparison of file modification time and size. If

--- a/doc/rst/dcp.1.rst
+++ b/doc/rst/dcp.1.rst
@@ -40,6 +40,10 @@ OPTIONS
 
    Run in verbose mode.
 
+.. option:: -q, --quiet
+
+   Run tool silently. No output is printed.
+
 .. option:: -h, --help
 
    Print a brief message listing the :manpage:`dcp(1)` options and usage.

--- a/doc/rst/ddup.1.rst
+++ b/doc/rst/ddup.1.rst
@@ -24,6 +24,14 @@ OPTIONS
 
    Set verbosity level.  LEVEL can be one of: fatal, err, warn, info, dbg.
 
+.. option:: -v, --verbose
+
+   Run in verbose mode.
+
+.. option:: -q, --quiet
+
+   Run tool silently. No output is printed.
+
 .. option:: -h, --help
 
    Print the command usage, and the list of options available.

--- a/doc/rst/dfind.1.rst
+++ b/doc/rst/dfind.1.rst
@@ -33,6 +33,10 @@ OPTIONS
 
    Run in verbose mode.
 
+.. option:: -q, --quiet
+
+   Run tool silently. No output is printed.
+
 .. option:: -h, --help
 
    Print a brief message listing the :manpage:`dfind(1)` options and usage.

--- a/doc/rst/dreln.1.rst
+++ b/doc/rst/dreln.1.rst
@@ -40,6 +40,10 @@ OPTIONS
 
    Run in verbose mode.
 
+.. option:: -q, --quiet
+
+   Run tool silently. No output is printed.
+
 .. option:: -h, --help
 
    Print a brief message listing the :manpage:`drm(1)` options and usage.

--- a/doc/rst/drm.1.rst
+++ b/doc/rst/drm.1.rst
@@ -72,6 +72,10 @@ OPTIONS
 
    Run in verbose mode.
 
+.. option:: -q, --quiet
+
+   Run tool silently. No output is printed.
+
 .. option:: -h, --help
 
    Print a brief message listing the :manpage:`drm(1)` options and usage.

--- a/doc/rst/dstripe.1.rst
+++ b/doc/rst/dstripe.1.rst
@@ -50,6 +50,10 @@ OPTIONS
 
    Run in verbose mode.
 
+.. option:: -q, --quiet
+
+   Run tool silently. No output is printed.
+
 .. option:: -h, --help
 
    Print the command usage, and the list of options available.

--- a/doc/rst/dsync.1.rst
+++ b/doc/rst/dsync.1.rst
@@ -41,6 +41,10 @@ OPTIONS
    command. Files walked, started, completed, seconds, files, bytes
    read, byte rate, and file rate.
 
+.. option:: -q, --quiet
+
+   Run tool silently. No output is printed.
+
 .. option:: -h, --help
 
    Print the command usage, and the list of options available.

--- a/doc/rst/dwalk.1.rst
+++ b/doc/rst/dwalk.1.rst
@@ -56,6 +56,10 @@ OPTIONS
 
    Run in verbose mode.
 
+.. option:: -q, --quiet
+
+   Run tool silently. No output is printed.
+
 .. option:: -h, --help
 
    Print usage.

--- a/src/common/mfu_util.h
+++ b/src/common/mfu_util.h
@@ -61,6 +61,7 @@ extern "C" {
 #endif
 
 typedef enum {
+    MFU_LOG_NONE    = 0,
     MFU_LOG_FATAL   = 1,
     MFU_LOG_ERR     = 2,
     MFU_LOG_WARN    = 3,

--- a/src/dbz2/dbz2.c
+++ b/src/dbz2/dbz2.c
@@ -39,6 +39,7 @@ static void print_usage(void)
     printf("  -b, --blocksize <num>  - block size (1-9)\n");
     printf("  -m, --memory <size>    - memory limit in bytes\n");
     printf("  -v, --verbose          - verbose output\n");
+    printf("  -q, --quiet            - quiet output\n");
     printf("      --debug            - debug output\n");
     printf("  -h, --help             - print usage\n");
     printf("\n");
@@ -66,15 +67,19 @@ int main(int argc, char** argv)
         {"blocksize",  1, 0, 'b'},        
         {"memory",     1, 0, 'm'},
         {"verbose",    0, 0, 'v'},
+        {"quiet",      0, 0, 'q'},
         {"debug",      0, 0, 'y'},
         {"help",       0, 0, 'h'},
         {0, 0, 0, 0}
     };
 
+    /* verbose by default */
+    mfu_debug_level = MFU_LOG_VERBOSE;
+
     int usage = 0;
     while (1) {
         int c = getopt_long(
-                    argc, argv, "cdkfb:m:vyh",
+                    argc, argv, "cdkfb:m:vqyh",
                     long_options, &option_index
                 );
 
@@ -104,10 +109,13 @@ int main(int argc, char** argv)
                 opts_memory = (ssize_t) bytes;
                 break;            
             case 'v':
-                opts_verbose = 1;
+                mfu_debug_level = MFU_LOG_VERBOSE;
+                break;
+            case 'q':
+                mfu_debug_level = MFU_LOG_NONE;
                 break;
             case 'y':
-                opts_debug = 1;
+                mfu_debug_level = MFU_LOG_DBG;
                 break;
             case 'h':
                 usage = 1;
@@ -120,15 +128,6 @@ int main(int argc, char** argv)
                     printf("?? getopt returned character code 0%o ??\n", c);
                 }
         }
-    }
-
-    /* Set the log level to control the messages that will be printed */
-    if (opts_debug) {
-        mfu_debug_level = MFU_LOG_DBG;
-    } else if (opts_verbose) {
-        mfu_debug_level = MFU_LOG_INFO;
-    } else {
-        mfu_debug_level = MFU_LOG_ERR;
     }
 
     /* TODO: also bail if we can't find the file */

--- a/src/dchmod/dchmod.c
+++ b/src/dchmod/dchmod.c
@@ -35,6 +35,7 @@ static void print_usage(void)
     printf("      --match   <regex>  - match a list of files from command\n");
     printf("  -n, --name             - exclude a list of files from command\n");
     printf("  -v, --verbose          - verbose output\n");
+    printf("  -q, --quiet            - quiet output\n");
     printf("  -h, --help             - print usage\n");
     printf("\n");
     fflush(stdout);
@@ -66,6 +67,9 @@ int main(int argc, char** argv)
     int exclude     = 0;
     int name        = 0;
 
+    /* verbose by default */
+    mfu_debug_level = MFU_LOG_VERBOSE;
+
     int option_index = 0;
     static struct option long_options[] = {
         {"input",    1, 0, 'i'},
@@ -77,13 +81,14 @@ int main(int argc, char** argv)
         {"name",     0, 0, 'n'},
         {"help",     0, 0, 'h'},
         {"verbose",  0, 0, 'v'},
+        {"quiet",    0, 0, 'q'},
         {0, 0, 0, 0}
     };
 
     int usage = 0;
     while (1) {
         int c = getopt_long(
-                    argc, argv, "i:g:m:nlhv",
+                    argc, argv, "i:g:m:nlhvq",
                     long_options, &option_index
                 );
 
@@ -120,6 +125,9 @@ int main(int argc, char** argv)
                 break;
             case 'v':
                 mfu_debug_level = MFU_LOG_VERBOSE;
+                break;
+            case 'q':
+                mfu_debug_level = MFU_LOG_NONE;
                 break;
             case '?':
                 usage = 1;

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -31,6 +31,7 @@ static void print_usage(void)
     printf("  -t, --text                - change output option to write in text format\n");
     printf("  -b, --base                - enable base checks and normal output with --output\n");
     printf("  -v, --verbose             - verbose output\n");
+    printf("  -q, --quiet               - quiet output\n");
     printf("  -l, --lite                - only compares file modification time and size\n");
     //printf("  -d, --debug               - run in debug mode\n");
     printf("  -h, --help                - print usage\n");
@@ -156,6 +157,7 @@ struct dcmp_output {
 struct dcmp_options {
     struct list_head outputs;      /* list of outputs */
     int verbose;
+    int quiet;
     int lite;
     int format;			   /* output data format, 0 for text, 1 for raw */
     int base;                      /* whether to do base check */
@@ -166,6 +168,7 @@ struct dcmp_options {
 struct dcmp_options options = {
     .outputs      = LIST_HEAD_INIT(options.outputs),
     .verbose      = 0,
+    .quiet        = 0,
     .lite         = 0,
     .format       = 1,
     .base         = 0,
@@ -1985,7 +1988,7 @@ int main(int argc, char **argv)
     /* By default, show info log messages. */
     /* we back off a level on CIRCLE verbosity since its INFO is verbose */
     CIRCLE_loglevel CIRCLE_debug = CIRCLE_LOG_WARN;
-    mfu_debug_level = MFU_LOG_INFO;
+    mfu_debug_level = MFU_LOG_VERBOSE;
 
     int option_index = 0;
     static struct option long_options[] = {
@@ -1993,6 +1996,7 @@ int main(int argc, char **argv)
         {"text",     0, 0, 't'},
         {"base",     0, 0, 'b'},
         {"verbose",  0, 0, 'v'},
+        {"quiet",    0, 0, 'q'},
         {"lite",     0, 0, 'l'},
         {"debug",    0, 0, 'd'},
         {"help",     0, 0, 'h'},
@@ -2006,7 +2010,7 @@ int main(int argc, char **argv)
     int help  = 0;
     while (1) {
         int c = getopt_long(
-            argc, argv, "bo:tvldh",
+            argc, argv, "bo:tvqldh",
             long_options, &option_index
         );
 
@@ -2030,6 +2034,10 @@ int main(int argc, char **argv)
         case 'v':
             options.verbose++;
             mfu_debug_level = MFU_LOG_VERBOSE;
+            break;
+        case 'q':
+            options.quiet++;
+            mfu_debug_level = MFU_LOG_NONE;
             break;
         case 'l':
             options.lite++;

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -70,6 +70,7 @@ void print_usage(void)
     printf("  -s, --synchronous   - use synchronous read/write calls (O_DIRECT)\n");
     printf("  -S, --sparse        - create sparse files when possible\n");
     printf("  -v, --verbose       - verbose output\n");
+    printf("  -q, --quiet         - quiet output\n");
     printf("  -h, --help          - print usage\n");
     printf("\n");
     fflush(stdout);
@@ -97,7 +98,9 @@ int main(int argc, char** argv)
     /* By default, show info log messages. */
     /* we back off a level on CIRCLE verbosity since its INFO is verbose */
     CIRCLE_loglevel CIRCLE_debug = CIRCLE_LOG_WARN;
-    mfu_debug_level = MFU_LOG_INFO;
+
+    /* verbose by default */
+    mfu_debug_level = MFU_LOG_VERBOSE;
 
     /* By default, don't have iput file. */
     char* inputname = NULL;
@@ -111,6 +114,7 @@ int main(int argc, char** argv)
         {"synchronous"          , no_argument      , 0, 's'},
         {"sparse"               , no_argument      , 0, 'S'},
         {"verbose"              , no_argument      , 0, 'v'},
+        {"quiet"                , no_argument      , 0, 'q'},
         {"help"                 , no_argument      , 0, 'h'},
         {0                      , 0                , 0, 0  }
     };
@@ -119,7 +123,7 @@ int main(int argc, char** argv)
     int usage = 0;
     while(1) {
         int c = getopt_long(
-                    argc, argv, "d:g:hi:pusSv",
+                    argc, argv, "d:g:hi:pusSvq",
                     long_options, &option_index
                 );
 
@@ -206,6 +210,9 @@ int main(int argc, char** argv)
                 break;
             case 'v':
                 mfu_debug_level = MFU_LOG_VERBOSE;
+                break;
+            case 'q':
+                mfu_debug_level = MFU_LOG_NONE;
                 break;
             case 'h':
                 usage = 1;

--- a/src/dcp1/dcp1.c
+++ b/src/dcp1/dcp1.c
@@ -268,6 +268,8 @@ void DCOPY_print_usage(void)
     printf("  -d, --debug <level> - specify debug verbosity level (default info)\n");
     printf("  -f, --force         - delete destination file if error on open\n");
     printf("  -p, --preserve      - preserve permissions, ownership, timestamps, extended attributes\n");
+    printf("  -p, --verbose       - verbose output\n");
+    printf("  -p, --quiet         - quiet output\n");
     printf("  -s, --synchronous   - use synchronous read/write calls (O_DIRECT)\n");
     printf("  -k, --chunksize     - specify chunksize in MB unit (default 1MB)\n");
     printf("  -b, --blocksize     - specify blocksize in MB unit (default 1MB)\n");
@@ -319,7 +321,9 @@ int main(int argc, \
     /* By default, show info log messages. */
     /* we back off a level on CIRCLE verbosity since its INFO is verbose */
     CIRCLE_loglevel CIRCLE_debug = CIRCLE_LOG_WARN;
-    mfu_debug_level = MFU_LOG_INFO;
+
+    /* verbose by default */
+    mfu_debug_level = MFU_LOG_VERBOSE;
 
     /* By default, don't unlink destination files if an open() fails. */
     DCOPY_user_opts.force = false;
@@ -341,6 +345,8 @@ int main(int argc, \
         {"help"                 , no_argument      , 0, 'h'},
         {"chunksize"            , required_argument, 0, 'k'},
         {"preserve"             , no_argument      , 0, 'p'},
+        {"verbose"              , no_argument      , 0, 'v'},
+        {"quiet"                , no_argument      , 0, 'q'},
         {"unreliable-filesystem", no_argument      , 0, 'u'},
         {"synchronous"          , no_argument      , 0, 's'},
         {0                      , 0                , 0, 0  }
@@ -348,7 +354,7 @@ int main(int argc, \
 
     /* Parse options */
     unsigned long long bytes;
-    while((c = getopt_long(argc, argv, "cb:d:fhpusvk:", \
+    while((c = getopt_long(argc, argv, "cb:d:fhpusvqk:", \
                            long_options, &option_index)) != -1) {
         switch(c) {
 
@@ -443,6 +449,14 @@ int main(int argc, \
                     MFU_LOG(MFU_LOG_INFO, "Preserving file attributes.");
                 }
 
+                break;
+
+            case 'v':
+                mfu_debug_level = MFU_LOG_VERBOSE;
+                break;
+
+            case 'q':
+                mfu_debug_level = MFU_LOG_NONE;
                 break;
 
             case 'u':

--- a/src/ddup/ddup.c
+++ b/src/ddup/ddup.c
@@ -25,6 +25,8 @@ static void print_usage(void)
     printf("Options:\n");
     printf("  -d, --debug <DEBUG>  - set verbosity, one of: fatal,err,warn,info,dbg\n");
     printf("  -h, --help           - print usage\n");
+    printf("  -v, --verbose        - verbose output\n");
+    printf("  -q, --quiet          - quiet output\n");
     printf("\n");
     fflush(stdout);
 }
@@ -170,11 +172,13 @@ int main(int argc, char** argv)
     /* pointer to mfu_walk_opts */
     mfu_walk_opts_t* walk_opts = mfu_walk_opts_new();
 
-    mfu_debug_level = MFU_LOG_INFO;
+    mfu_debug_level = MFU_LOG_VERBOSE;
 
     static struct option long_options[] = {
         {"debug",    0, 0, 'd'},
         {"help",     0, 0, 'h'},
+        {"verbose",  0, 0, 'v'},
+        {"quiet",    0, 0, 'q'},
         {0, 0, 0, 0}
     };
 
@@ -183,7 +187,7 @@ int main(int argc, char** argv)
     int help  = 0;
     int c;
     int option_index = 0;
-    while ((c = getopt_long(argc, argv, "d:h", \
+    while ((c = getopt_long(argc, argv, "d:hvq", \
                             long_options, &option_index)) != -1)
     {
         switch (c) {
@@ -233,6 +237,12 @@ int main(int argc, char** argv)
                               "`info'.", optarg);
             }
         case 'h':
+        case 'v':
+            mfu_debug_level = MFU_LOG_VERBOSE;
+            break;
+        case 'q':
+            mfu_debug_level = MFU_LOG_NONE;
+            break;
         case '?':
             usage = 1;
             help  = 1;

--- a/src/dfind/dfind.c
+++ b/src/dfind/dfind.c
@@ -64,6 +64,7 @@ static void print_usage(void)
     printf("  -i, --input <file>                      - read list from file\n");
     printf("  -o, --output <file>                     - write processed list to file\n");
     printf("  -v, --verbose                           - verbose output\n");
+    printf("  -q, --quiet                             - quiet output\n");
     printf("  -h, --help                              - print usage\n");
     printf("\n");
     fflush(stdout);
@@ -183,6 +184,7 @@ int main (int argc, char** argv)
         {"input",     1, 0, 'i'},
         {"output",    1, 0, 'o'},
         {"verbose",   0, 0, 'v'},
+        {"quiet",     0, 0, 'q'},
         {"help",      0, 0, 'h'},
 
         { "maxdepth", required_argument, NULL, 'd' },
@@ -222,7 +224,7 @@ int main (int argc, char** argv)
     int usage = 0;
     while (1) {
         int c = getopt_long(
-                    argc, argv, "i:o:t:",
+                    argc, argv, "i:o:t:vqh",
                     long_options, NULL
                 );
 
@@ -237,6 +239,10 @@ int main (int argc, char** argv)
         mfu_pred_times_rel* tr;
         regex_t* r;
         int ret;
+
+        /* verbose by default */
+        mfu_debug_level = MFU_LOG_VERBOSE;
+
     	switch (c) {
     	case 'e':
             space = 1024 * 1024;
@@ -389,6 +395,9 @@ int main (int argc, char** argv)
             break;
         case 'v':
             mfu_debug_level = MFU_LOG_VERBOSE;
+            break;
+        case 'q':
+            mfu_debug_level = MFU_LOG_NONE;
             break;
         case 'h':
             usage = 1;

--- a/src/dreln/dreln.c
+++ b/src/dreln/dreln.c
@@ -17,6 +17,7 @@ static void print_usage(void)
     printf("  -p, --preserve     - preserve link modification timestamps\n");
     printf("  -r, --relative     - change targets from absolute to relative paths\n");
     printf("  -v, --verbose      - verbose output\n");
+    printf("  -q, --quiet        - quiet output\n");
     printf("  -h, --help         - print usage\n");
     printf("\n");
     fflush(stdout);
@@ -45,8 +46,8 @@ int main (int argc, char* argv[])
     /* whether path to target should be relative from symlink */
     int relative_targets = 0;
 
-    /* set debug level to MFU_LOG_INFO since it defaults to ERROR */
-    mfu_debug_level = MFU_LOG_INFO;
+    /* set debug level to verbose by default */
+    mfu_debug_level = MFU_LOG_VERBOSE;
 
     /* define allowed command line optinos */
     int option_index = 0;
@@ -55,6 +56,7 @@ int main (int argc, char* argv[])
         {"preserve",     0, 0, 'p'},
         {"relative",     0, 0, 'r'},
         {"verbose",      0, 0, 'v'},
+        {"quiet",        0, 0, 'q'},
         {"help",         0, 0, 'h'},
         {0, 0, 0, 0}
     };
@@ -63,7 +65,7 @@ int main (int argc, char* argv[])
     int usage = 0;
     while (1) {
         int c = getopt_long(
-                    argc, argv, "i:prvh",
+                    argc, argv, "i:prvqh",
                     long_options, &option_index
                 );
 
@@ -83,6 +85,9 @@ int main (int argc, char* argv[])
                 break;
             case 'v':
                 mfu_debug_level = MFU_LOG_VERBOSE;
+                break;
+            case 'q':
+                mfu_debug_level = MFU_LOG_NONE;
                 break;
             case 'h':
                 usage = 1;

--- a/src/drm/drm.c
+++ b/src/drm/drm.c
@@ -40,6 +40,7 @@ static void print_usage(void)
     printf("  -T, --traceless        - remove child items without changing parent directory mtime\n");
     printf("      --aggressive       - aggressive mode deletes files during the walk. You CANNOT use dryrun with this option. \n");
     printf("  -v, --verbose          - verbose output\n");
+    printf("  -q, --quiet            - quiet output\n");
     printf("  -h, --help             - print usage\n");
     printf("\n");
     fflush(stdout);
@@ -73,6 +74,9 @@ int main(int argc, char** argv)
     /* Don't stat on walk by default */
     walk_opts->use_stat = 0;
 
+    /* verbose by default */
+    mfu_debug_level = MFU_LOG_VERBOSE;
+
     int option_index = 0;
     static struct option long_options[] = {
         {"input",       1, 0, 'i'},
@@ -83,6 +87,7 @@ int main(int argc, char** argv)
         {"dryrun",      0, 0, 'd'},
         {"aggressive",  0, 0, 'A'},
         {"verbose",     0, 0, 'v'},
+        {"quiet",       0, 0, 'q'},
         {"traceless",   0, 0, 'T'},
         {"help",        0, 0, 'h'},
         {0, 0, 0, 0}
@@ -91,7 +96,7 @@ int main(int argc, char** argv)
     int usage = 0;
     while (1) {
         int c = getopt_long(
-                    argc, argv, "i:lhvT",
+                    argc, argv, "i:lhvqT",
                     long_options, &option_index
                 );
 
@@ -123,6 +128,9 @@ int main(int argc, char** argv)
                 break;
             case 'v':
                 mfu_debug_level = MFU_LOG_VERBOSE;
+                break;
+            case 'q':
+                mfu_debug_level = MFU_LOG_NONE;
                 break;
             case 'A':
                 walk_opts->remove = 1;

--- a/src/dstripe/dstripe.c
+++ b/src/dstripe/dstripe.c
@@ -26,6 +26,7 @@ static void print_usage(void)
     printf("  -m, --minsize <SIZE>   - minimum file size (default 0MB)\n");
     printf("  -r, --report           - display file size and stripe info\n");
     printf("  -v, --verbose          - verbose output\n");
+    printf("  -q, --quiet            - quiet output\n");
     printf("  -h, --help             - print usage\n");
     printf("\n");
     fflush(stdout);
@@ -316,10 +317,12 @@ int main(int argc, char* argv[])
     int option_index = 0;
     int usage = 0;
     int report = 0;
-    int verbose = 0;
     unsigned int numpaths = 0;
     mfu_param_path* paths = NULL;
     unsigned long long bytes;
+
+    /* verbose by default */
+    mfu_debug_level = MFU_LOG_VERBOSE;
 
     /* default to 1MB stripe size, stripe across all OSTs, and all files are candidates */
     int stripes = -1;
@@ -331,12 +334,14 @@ int main(int argc, char* argv[])
         {"size",     1, 0, 's'},
         {"minsize",  1, 0, 'm'},
         {"help",     0, 0, 'h'},
+        {"verbose",  0, 0, 'v'},
+        {"quiet",    0, 0, 'q'},
         {"report",   0, 0, 'r'},
         {0, 0, 0, 0}
     };
 
     while (1) {
-        int c = getopt_long(argc, argv, "c:s:m:rhv",
+        int c = getopt_long(argc, argv, "c:s:m:rhvq",
                     long_options, &option_index);
 
         if (c == -1) {
@@ -375,8 +380,10 @@ int main(int argc, char* argv[])
 		report = 1;
                 break;
             case 'v':
-                /* verbose output */
-                verbose = 1;
+                mfu_debug_level = MFU_LOG_VERBOSE;
+                break;
+            case 'q':
+                mfu_debug_level = MFU_LOG_NONE;
                 break;
             case 'h':
                 /* display usage */

--- a/src/dsync/dsync.c
+++ b/src/dsync/dsync.c
@@ -52,6 +52,7 @@ static void print_usage(void)
     printf("  -c, --contents        - read and compare file contents rather than compare size and mtime\n");
     printf("  -D, --delete          - delete extraneous files from target\n");
     printf("  -v, --verbose         - verbose output\n");
+    printf("  -q, --quiet           - quiet output\n");
     printf("  -h, --help            - print usage\n");
     printf("\n");
     fflush(stdout);
@@ -155,6 +156,7 @@ struct dsync_options {
     int contents;                  /* check file contents rather than size and mtime */
     int dry_run;                   /* dry run */
     int verbose;
+    int quiet;
     int debug;                     /* check result after get result */
     int delete;                    /* delete extraneous files from destination dirs */
     int need_compare[DCMPF_MAX];   /* fields that need to be compared  */
@@ -165,6 +167,7 @@ struct dsync_options options = {
     .contents     = 0,
     .dry_run      = 0,
     .verbose      = 0,
+    .quiet        = 0,
     .debug        = 0,
     .delete       = 0,
     .need_compare = {0,}
@@ -2154,7 +2157,9 @@ int main(int argc, char **argv)
     /* By default, show info log messages. */
     /* we back off a level on CIRCLE verbosity since its INFO is verbose */
     CIRCLE_loglevel CIRCLE_debug = CIRCLE_LOG_WARN;
-    mfu_debug_level = MFU_LOG_INFO;
+
+    /* verbose by default */
+    mfu_debug_level = MFU_LOG_VERBOSE;
 
     /* By default, sync option will preserve all attributes. */
     mfu_copy_opts->preserve = true;
@@ -2171,6 +2176,7 @@ int main(int argc, char **argv)
         {"output",        1, 0, 'o'},
         {"debug",         0, 0, 'd'},
         {"verbose",       0, 0, 'v'},
+        {"quiet",         0, 0, 'q'},
         {"help",          0, 0, 'h'},
         {0, 0, 0, 0}
     };
@@ -2186,7 +2192,7 @@ int main(int argc, char **argv)
 
     while (1) {
         int c = getopt_long(
-            argc, argv, "b:cDo:dvh",
+            argc, argv, "b:cDo:dvqh",
             long_options, &option_index
         );
 
@@ -2219,6 +2225,10 @@ int main(int argc, char **argv)
         case 'v':
             options.verbose++;
             mfu_debug_level = MFU_LOG_VERBOSE;
+            break;
+        case 'q':
+            options.quiet++;
+            mfu_debug_level = MFU_LOG_NONE;
             break;
         case 'h':
         case '?':

--- a/src/dwalk/dwalk.c
+++ b/src/dwalk/dwalk.c
@@ -244,6 +244,7 @@ static void print_usage(void)
     printf("  -d, --distribution <field>:<separators> - print distribution by field\n");
     printf("  -p, --print                             - print files to screen\n");
     printf("  -v, --verbose                           - verbose output\n");
+    printf("  -q, --quiet                             - quiet output\n");
     printf("  -h, --help                              - print usage\n");
     printf("\n");
     printf("Fields: name,user,group,uid,gid,atime,mtime,ctime,size\n");
@@ -288,8 +289,8 @@ int main(int argc, char** argv)
     int text                 = 0;
     struct distribute_option option;
 
-    /* set debug level to MFU_LOG_INFO since it defaults to ERROR */
-    mfu_debug_level = MFU_LOG_INFO;
+    /* verbose by default */
+    mfu_debug_level = MFU_LOG_VERBOSE;
 
     int option_index = 0;
     static struct option long_options[] = {
@@ -300,6 +301,7 @@ int main(int argc, char** argv)
         {"distribution", 1, 0, 'd'},
         {"print",        0, 0, 'p'},
         {"verbose",      0, 0, 'v'},
+        {"quiet",        0, 0, 'q'},
         {"help",         0, 0, 'h'},
         {"text",         0, 0, 't'},
         {0, 0, 0, 0}
@@ -308,7 +310,7 @@ int main(int argc, char** argv)
     int usage = 0;
     while (1) {
         int c = getopt_long(
-                    argc, argv, "i:o:ls:d:pvht",
+                    argc, argv, "i:o:ls:d:pvqht",
                     long_options, &option_index
                 );
 
@@ -338,6 +340,9 @@ int main(int argc, char** argv)
                 break;
             case 'v':
                 mfu_debug_level = MFU_LOG_VERBOSE;
+                break;
+            case 'q':
+                mfu_debug_level = 0;
                 break;
             case 't':
                 text = 1;

--- a/test/legacy/dcp1_tests/test_all.sh
+++ b/test/legacy/dcp1_tests/test_all.sh
@@ -9,14 +9,15 @@
 # Turn this on if you want output from each test printed out.
 DEBUG=1
 
-# A temporary directory that all tests can use for scratch files.
-TEST_TMP_DIR=../tmp
+# set environment variables (TEST_TMP_DIR & TEST_DCP_BIN to run tests)
+TEST_TMP_DIR=$1
+TEST_DCP_BIN=$2
 
-# The dcp1 binary path to use. This must be relative to the test_all.sh script.
-TEST_DCP_BIN=../src/dcp1
-
-# The mpirun binary to use.
-TEST_MPIRUN_BIN=/usr/bin/mpirun
+if [ -z $TEST_TMP_DIR ] || [ -z $TEST_DCP_BIN ]; then
+    echo 'Please set TEST_TMP_DIR and TEST_DCP_BIN'
+    echo 'i.e ./test_all.sh /tmp/<username> /path/to/dcp1/install'
+    exit 1
+fi
 
 # The cmp binary to use.
 TEST_CMP_BIN=/usr/bin/cmp
@@ -39,7 +40,7 @@ pushd $TESTS_DIR > /dev/null
 mkdir $TEST_TMP_DIR
 
 echo "# =============================================================================="
-echo "# Running ALL tests for DCP."
+echo "# Running ALL tests for DCP1."
 echo "# =============================================================================="
 echo "# Tests started at: $(date)"
 echo "# =============================================================================="
@@ -47,7 +48,7 @@ echo "# ========================================================================
 # Fix up the tmp and bin paths for subshells.
 export DCP_TEST_BIN=$(readlink -f $TEST_DCP_BIN)
 export DCP_TEST_TMP=$(readlink -f $TEST_TMP_DIR)
-export DCP_MPIRUN_BIN=$(readlink -f $TEST_MPIRUN_BIN)
+#export DCP_MPIRUN_BIN=$(readlink -f $TEST_MPIRUN_BIN)
 export DCP_CMP_BIN=$(readlink -f $TEST_CMP_BIN)
 
 # Tell the tests what mode we're in

--- a/test/legacy/dcp1_tests/test_dcp1_many_dir_to_single_dir/test.sh
+++ b/test/legacy/dcp1_tests/test_dcp1_many_dir_to_single_dir/test.sh
@@ -20,7 +20,6 @@
 
 # Print out the basic paths we'll be using.
 echo "Using dcp1 binary at: $DCP_TEST_BIN"
-echo "Using mpirun binary at: $DCP_MPIRUN_BIN"
 echo "Using tmp directory at: $DCP_TEST_TMP"
 
 ##############################################################################
@@ -59,7 +58,7 @@ dd if=/dev/urandom of=$PATH_G_RANDOM bs=3M count=2
 # Test copying several directories to a directory. The result should be the directories
 # placed inside the directory.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN -R $PATH_A_DIRECTORY $PATH_B_DIRECTORY $PATH_C_DIRECTORY $PATH_D_DIRECTORY
+mpirun -n 3 $DCP_TEST_BIN $PATH_A_DIRECTORY $PATH_B_DIRECTORY $PATH_C_DIRECTORY $PATH_D_DIRECTORY
 if [[ $? -ne 0 ]]; then
     echo "Error returned when copying an several directories to a directory (A,B,C -> D)."
     exit 1;

--- a/test/legacy/dcp1_tests/test_dcp1_many_dir_to_single_file/test.sh
+++ b/test/legacy/dcp1_tests/test_dcp1_many_dir_to_single_file/test.sh
@@ -20,7 +20,6 @@
 
 # Print out the basic paths we'll be using.
 echo "Using dcp1 binary at: $DCP_TEST_BIN"
-echo "Using mpirun binary at: $DCP_MPIRUN_BIN"
 echo "Using tmp directory at: $DCP_TEST_TMP"
 
 ##############################################################################
@@ -62,7 +61,7 @@ mkdir $PATH_G_DIRECTORY
 # Test copying several directories into an empty file. This should result in
 # an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_D_DIRECTORY $PATH_E_DIRECTORY $PATH_F_DIRECTORY $PATH_A_EMPTY
+mpirun -n 3 $DCP_TEST_BIN $PATH_D_DIRECTORY $PATH_E_DIRECTORY $PATH_F_DIRECTORY $PATH_A_EMPTY
 if [[ $? -eq 0 ]]; then
     echo "Unexpected success when copying several directories to an empty file. (D,E,F -> A)."
     exit 1;
@@ -72,7 +71,7 @@ fi
 # Test copying several directories into a random file. This should result in
 # an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_D_DIRECTORY $PATH_E_DIRECTORY $PATH_F_DIRECTORY $PATH_B_RANDOM
+mpirun -n 3 $DCP_TEST_BIN $PATH_D_DIRECTORY $PATH_E_DIRECTORY $PATH_F_DIRECTORY $PATH_B_RANDOM
 if [[ $? -eq 0 ]]; then
     echo "Unexpected success when copying several directories to a random file. (D,E,F -> B)."
     exit 1;
@@ -82,7 +81,7 @@ fi
 # Test copying several directories into a no-exist file. This should result in
 # an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_D_DIRECTORY $PATH_E_DIRECTORY $PATH_F_DIRECTORY $PATH_C_NOEXIST
+mpirun -n 3 $DCP_TEST_BIN $PATH_D_DIRECTORY $PATH_E_DIRECTORY $PATH_F_DIRECTORY $PATH_C_NOEXIST
 if [[ $? -eq 0 ]]; then
     echo "Unexpected success when copying several directories to a no-exist file. (D,E,F -> C)."
     exit 1;

--- a/test/legacy/dcp1_tests/test_dcp1_many_file_to_single_dir/test.sh
+++ b/test/legacy/dcp1_tests/test_dcp1_many_file_to_single_dir/test.sh
@@ -20,7 +20,6 @@
 
 # Print out the basic paths we'll be using.
 echo "Using dcp1 binary at: $DCP_TEST_BIN"
-echo "Using mpirun binary at: $DCP_MPIRUN_BIN"
 echo "Using tmp directory at: $DCP_TEST_TMP"
 
 ##############################################################################
@@ -56,7 +55,7 @@ mkdir $PATH_E_DIRECTORY
 # Test copying several files to a directory. The result should be the files
 # placed inside the directory.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_A_EMPTY $PATH_C_RANDOM $PATH_B_EMPTY $PATH_D_RANDOM $PATH_E_DIRECTORY
+mpirun -n 3 $DCP_TEST_BIN $PATH_A_EMPTY $PATH_C_RANDOM $PATH_B_EMPTY $PATH_D_RANDOM $PATH_E_DIRECTORY
 if [[ $? -ne 0 ]]; then
     echo "Error returned when copying an several files to a directory (A,B,C,D -> E)."
     exit 1;

--- a/test/legacy/dcp1_tests/test_dcp1_many_file_to_single_file/test.sh
+++ b/test/legacy/dcp1_tests/test_dcp1_many_file_to_single_file/test.sh
@@ -20,7 +20,6 @@
 
 # Print out the basic paths we'll be using.
 echo "Using dcp1 binary at: $DCP_TEST_BIN"
-echo "Using mpirun binary at: $DCP_MPIRUN_BIN"
 echo "Using tmp directory at: $DCP_TEST_TMP"
 
 ##############################################################################
@@ -64,7 +63,7 @@ dd if=/dev/urandom of=$PATH_H_RANDOM bs=6M count=2
 # Test copying several empty files into an empty file. This should result in
 # an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_A_EMPTY $PATH_B_EMPTY $PATH_C_EMPTY $PATH_D_EMPTY
+mpirun -n 3 $DCP_TEST_BIN $PATH_A_EMPTY $PATH_B_EMPTY $PATH_C_EMPTY $PATH_D_EMPTY
 if [[ $? -eq 0 ]]; then
     echo "Unexpected success when copying empty files to an empty file. (A,B,C -> D)."
     exit 1;
@@ -74,7 +73,7 @@ fi
 # Test copying several empty files into a random file. This should result in
 # an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_A_EMPTY $PATH_B_EMPTY $PATH_C_EMPTY $PATH_E_EMPTY
+mpirun -n 3 $DCP_TEST_BIN $PATH_A_EMPTY $PATH_B_EMPTY $PATH_C_EMPTY $PATH_E_EMPTY
 if [[ $? -eq 0 ]]; then
     echo "Unexpected success when copying empty files to a random file (A,B,C -> E)."
     exit 1;
@@ -84,7 +83,7 @@ fi
 # Test copying several random files into an empty file. This should result in
 # an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_E_RANDOM $PATH_F_RANDOM $PATH_G_RANDOM $PATH_A_EMPTY
+mpirun -n 3 $DCP_TEST_BIN $PATH_E_RANDOM $PATH_F_RANDOM $PATH_G_RANDOM $PATH_A_EMPTY
 if [[ $? -eq 0 ]]; then
     echo "Unexpected success when copying random files to an empty file (E,F,G -> A)."
     exit 1;
@@ -94,7 +93,7 @@ fi
 # Test copying several random files into a file that doesn't exist. This
 # should result in an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_E_RANDOM $PATH_F_RANDOM $PATH_G_RANDOM $PATH_I_NOEXIST
+mpirun -n 3 $DCP_TEST_BIN $PATH_E_RANDOM $PATH_F_RANDOM $PATH_G_RANDOM $PATH_I_NOEXIST
 if [[ $? -eq 0 ]]; then
     echo "Unexpected success when copying random files to a no-exist file (E,F,G -> I)."
     exit 1;

--- a/test/legacy/dcp1_tests/test_dcp1_single_dir_to_single_dir/test.sh
+++ b/test/legacy/dcp1_tests/test_dcp1_single_dir_to_single_dir/test.sh
@@ -20,7 +20,6 @@
 
 # Print out the basic paths we'll be using.
 echo "Using dcp1 binary at: $DCP_TEST_BIN"
-echo "Using mpirun binary at: $DCP_MPIRUN_BIN"
 echo "Using tmp directory at: $DCP_TEST_TMP"
 
 ##############################################################################
@@ -47,7 +46,7 @@ dd if=/dev/urandom of=$PATH_C_RANDOM bs=3M count=2
 # Test copying a directory to a directory. The result should be the directory
 # placed inside the directory.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN -R $PATH_A_DIRECTORY $PATH_B_DIRECTORY
+mpirun -n 3 $DCP_TEST_BIN $PATH_A_DIRECTORY $PATH_B_DIRECTORY
 if [[ $? -ne 0 ]]; then
     echo "Error returned when copying a directory to a directory (A -> B)."
     exit 1;

--- a/test/legacy/dcp1_tests/test_dcp1_single_dir_to_single_file/test.sh
+++ b/test/legacy/dcp1_tests/test_dcp1_single_dir_to_single_file/test.sh
@@ -20,7 +20,6 @@
 
 # Print out the basic paths we'll be using.
 echo "Using dcp1 binary at: $DCP_TEST_BIN"
-echo "Using mpirun binary at: $DCP_MPIRUN_BIN"
 echo "Using tmp directory at: $DCP_TEST_TMP"
 
 ##############################################################################
@@ -46,7 +45,7 @@ dd if=/dev/urandom of=$PATH_C_RANDOM bs=4M count=5
 ##############################################################################
 # Test copying the directory to an empty file. The result should be an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_A_DIRECTORY $PATH_B_EMPTY
+mpirun -n 3 $DCP_TEST_BIN $PATH_A_DIRECTORY $PATH_B_EMPTY
 if [[ $? -eq 0 ]]; then
     echo "Unexpectedd success when copying a directory to an empty file. (A -> B)."
     exit 1;
@@ -55,7 +54,7 @@ fi
 ##############################################################################
 # Test copying a directory to a random file. The result should be an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_A_DIRECTORY $PATH_C_RANDOM
+mpirun -n 3 $DCP_TEST_BIN $PATH_A_DIRECTORY $PATH_C_RANDOM
 if [[ $? -eq 0 ]]; then
     echo "Unexpected success when copying a directory to a random file (A -> C)."
     exit 1;

--- a/test/legacy/dcp1_tests/test_dcp1_single_file_to_single_dir/test.sh
+++ b/test/legacy/dcp1_tests/test_dcp1_single_file_to_single_dir/test.sh
@@ -20,7 +20,6 @@
 
 # Print out the basic paths we'll be using.
 echo "Using dcp1 binary at: $DCP_TEST_BIN"
-echo "Using mpirun binary at: $DCP_MPIRUN_BIN"
 echo "Using cmp binary at: $DCP_CMP_BIN"
 echo "Using tmp directory at: $DCP_TEST_TMP"
 
@@ -52,7 +51,7 @@ mkdir $PATH_D_DIRECTORY
 ##############################################################################
 # Test copying a no-exist file to a directory. The result should be an error.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_A_NOEXIST $PATH_D_DIRECTORY
+mpirun -n 3 $DCP_TEST_BIN $PATH_A_NOEXIST $PATH_D_DIRECTORY
 
 if [[ $? -eq 0 ]]; then
     echo "Unexpected success when copying a no-exist file to a directory (A -> D)."
@@ -63,7 +62,7 @@ fi
 # Test copying an empty file to a directory. The result should be the empty
 # file placed inside the directory.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_B_EMPTY $PATH_D_DIRECTORY
+mpirun -n 3 $DCP_TEST_BIN $PATH_B_EMPTY $PATH_D_DIRECTORY
 if [[ $? -ne 0 ]]; then
     echo "Error returned when copying an empty file to a directory (B -> D)."
     exit 1;
@@ -79,7 +78,7 @@ fi
 # Test copying an empty file to a directory. The result should be the empty
 # file placed inside the directory.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_C_RANDOM $PATH_D_DIRECTORY
+mpirun -n 3 $DCP_TEST_BIN $PATH_C_RANDOM $PATH_D_DIRECTORY
 if [[ $? -ne 0 ]]; then
     echo "Error returned when copying a random file to a directory (C -> D)."
     exit 1;

--- a/test/legacy/dcp1_tests/test_dcp1_single_file_to_single_file/test.sh
+++ b/test/legacy/dcp1_tests/test_dcp1_single_file_to_single_file/test.sh
@@ -23,7 +23,6 @@
 
 # Print out the basic paths we'll be using.
 echo "Using dcp1 binary at: $DCP_TEST_BIN"
-echo "Using mpirun binary at: $DCP_MPIRUN_BIN"
 echo "Using cmp binary at: $DCP_CMP_BIN"
 echo "Using tmp directory at: $DCP_TEST_TMP"
 
@@ -61,7 +60,7 @@ stat $PATH_E_RANDOM
 # Test copying an empty file to an empty file. The result should be two files
 # which remain empty with no error output.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_B_EMPTY $PATH_C_EMPTY
+mpirun -n 3 $DCP_TEST_BIN $PATH_B_EMPTY $PATH_C_EMPTY
 
 if [[ $? -ne 0 ]]; then
     echo "Error returned when copying empty file to empty file (B -> C)."
@@ -78,7 +77,7 @@ fi
 # Test copying a random file to an empty file. The result should be two files
 # which both contain the contents of the first random file.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_D_RANDOM $PATH_B_EMPTY
+mpirun -n 3 $DCP_TEST_BIN $PATH_D_RANDOM $PATH_B_EMPTY
 if [[ $? -ne 0 ]]; then
     echo "Error returned when copying random file to empty file (D -> B)."
     exit 1;
@@ -94,7 +93,7 @@ fi
 # Test copying a random file to another random  file. The result should be two
 # files which both contain the contents of the first random file.
 
-$DCP_MPIRUN_BIN -np 3 $DCP_TEST_BIN $PATH_D_RANDOM $PATH_E_RANDOM
+mpirun -n 3 $DCP_TEST_BIN $PATH_D_RANDOM $PATH_E_RANDOM
 if [[ $? -ne 0 ]]; then
     echo "Error returned when copying random file to random file (D -> E)."
     exit 1;


### PR DESCRIPTION
Make tools verbose by default, and add quiet option to turn off output if desired. This did not apply to dbcast and both dfilemaker tools as neither are currently using verbose output.

    - Make tools verbose by default
    - add quiet option
    - pass mfu_debug_level to mfu_flist_unlink
    - update docs