### PR TITLE
dsync: add link-dest support

### DIFF
--- a/doc/rst/dsync.1.rst
+++ b/doc/rst/dsync.1.rst
@@ -35,6 +35,16 @@ OPTIONS
 
    Delete extraneous files from destination.
 
+.. option:: -l, --link-dest=LINK_DIR
+
+   Create hardlink to files in LINK_DIR when unchanged, rather than
+   creating file and copying data. Means, users can use this option
+   to achieve the goal of an incremental backup, and save storage space.
+   For example:
+   dsync /src/ /init_backup/
+   dsync -l /init_backup/ /src/ /incremental_backup_19_4_20/
+   dsync -l /init_backup/ /src/ /incremental_backup_19_4_29/
+
 .. option:: --progress N
 
    Print progress message to stdout approximately every N seconds.

--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -448,6 +448,16 @@ int mfu_flist_copy(
     mfu_copy_opts_t* mfu_copy_opts  /* IN - options to be used during copy */
 );
 
+/* link items in list from source paths to destination,
+ * each item in source list must come from the
+ * source path, returns 0 on success -1 on error */
+int mfu_flist_hardlink(
+    mfu_flist src_link_list,         /* IN - flist providing source items */
+    const mfu_param_path* srcpath,   /* IN - the source patht */
+    const mfu_param_path* destpath,  /* IN - destination path */
+    mfu_copy_opts_t* mfu_copy_opts   /* IN - options to be used during copy */
+);
+
 /* allocate a new mfu_walk_opts structure,
  * and set its fields with default values */
 mfu_walk_opts_t* mfu_walk_opts_new(void);

--- a/src/common/mfu_io.c
+++ b/src/common/mfu_io.c
@@ -229,6 +229,27 @@ retry:
     return rc;
 }
 
+/* call hardlink, retry a few times on EINTR or EIO */
+int mfu_hardlink(const char* oldpath, const char* newpath)
+{
+    int rc;
+    int tries = MFU_IO_TRIES;
+retry:
+    errno = 0;
+    rc = link(oldpath, newpath);
+    if (rc < 0) {
+        if (errno == EINTR || errno == EIO) {
+            tries--;
+            if (tries > 0) {
+                /* sleep a bit before consecutive tries */
+                usleep(MFU_IO_USLEEP);
+                goto retry;
+            }
+        }
+    }
+    return rc;
+}
+
 /*****************************
  * Files
  ****************************/

--- a/src/common/mfu_io.h
+++ b/src/common/mfu_io.h
@@ -80,6 +80,9 @@ ssize_t mfu_readlink(const char* path, char* buf, size_t bufsize);
 /* call symlink, retry a few times on EINTR or EIO */
 int mfu_symlink(const char* oldpath, const char* newpath);
 
+/* call hardlink, retry a few times on EINTR or EIO */
+int mfu_hardlink(const char* oldpath, const char* newpath);
+
 /*****************************
  * Files
  ****************************/


### PR DESCRIPTION
 -l, --link-dest=DIR   - hardlink to files in DIR when unchanged

dsync -l /link_dest_dir/ /src/ /dst/

Signed-off-by: Gu Zheng <gzheng@ddn.com>