### PR TITLE
dcp: style edits to chunk/block size options

### DIFF
--- a/doc/rst/dcp.1.rst
+++ b/doc/rst/dcp.1.rst
@@ -15,7 +15,7 @@ dcp is a file copy tool in the spirit of :manpage:`cp(1)` that evenly
 distributes the work of scanning the directory tree, and copying file
 data across a large cluster without any centralized state.  It is
 designed for copying files that are located on a distributed parallel
-file system, and will split large file copies across multiple processes.
+file system, and it splits large file copies across multiple processes.
 
 OPTIONS
 -------

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -112,10 +112,10 @@ int main(int argc, char** argv)
     int option_index = 0;
     static struct option long_options[] = {
         {"blocksize"            , required_argument, 0, 'b'},
-        {"chunksize"            , required_argument, 0, 'k'},
         {"debug"                , required_argument, 0, 'd'}, // undocumented
         {"grouplock"            , required_argument, 0, 'g'}, // untested
         {"input"                , required_argument, 0, 'i'},
+        {"chunksize"            , required_argument, 0, 'k'},
         {"preserve"             , no_argument      , 0, 'p'},
         {"synchronous"          , no_argument      , 0, 's'},
         {"sparse"               , no_argument      , 0, 'S'},
@@ -142,9 +142,10 @@ int main(int argc, char** argv)
         switch(c) {
             case 'b':
                 if (mfu_abtoull(optarg, &bytes) != MFU_SUCCESS || bytes == 0) {
-                    if (rank == 0)
+                    if (rank == 0) {
                         MFU_LOG(MFU_LOG_ERR,
-                                "Failed to parse block size: '%s'\n", optarg);
+                                "Failed to parse block size: '%s'", optarg);
+                    }
                     usage = 1;
                 } else {
                     mfu_copy_opts->block_size = (size_t)bytes;
@@ -210,9 +211,10 @@ int main(int argc, char** argv)
                 break;
             case 'k':
                 if (mfu_abtoull(optarg, &bytes) != MFU_SUCCESS || bytes == 0) {
-                    if (rank == 0)
+                    if (rank == 0) {
                         MFU_LOG(MFU_LOG_ERR,
-                                "Failed to parse chunk size: '%s'\n", optarg);
+                                "Failed to parse chunk size: '%s'", optarg);
+                    }
                     usage = 1;
                 } else {
                     mfu_copy_opts->chunk_size = bytes;


### PR DESCRIPTION
* always use braces
* no need for newline in MFU_LOG messages
* list options in consistent order between man page, print_usage, long opts, getopt string, and getopt while loop
* list verbose, quiet, and help as last options
* dcp: fix: have all ranks exit if chunksize/blocksize argument fails to parse

Signed-off-by: Adam Moody <moody20@llnl.gov>