### PR TITLE
progress: disable progress messages with --quiet

### DIFF
--- a/src/dchmod/dchmod.c
+++ b/src/dchmod/dchmod.c
@@ -131,6 +131,9 @@ int main(int argc, char** argv)
                 break;
             case 'q':
                 mfu_debug_level = MFU_LOG_NONE;
+                /* since process won't be printed in quiet anyway,
+                 * disable the algorithm to save some overhead */
+                mfu_progress_timeout = 0;
                 break;
             case 'h':
                 usage = 1;

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -2107,6 +2107,9 @@ int main(int argc, char **argv)
         case 'q':
             options.quiet++;
             mfu_debug_level = MFU_LOG_NONE;
+            /* since process won't be printed in quiet anyway,
+             * disable the algorithm to save some overhead */
+            mfu_progress_timeout = 0;
             break;
         case 'l':
             options.lite++;

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -246,6 +246,9 @@ int main(int argc, char** argv)
                 break;
             case 'q':
                 mfu_debug_level = MFU_LOG_NONE;
+                /* since process won't be printed in quiet anyway,
+                 * disable the algorithm to save some overhead */
+                mfu_progress_timeout = 0;
                 break;
             case 'h':
                 usage = 1;

--- a/src/dreln/dreln.c
+++ b/src/dreln/dreln.c
@@ -126,6 +126,9 @@ int main (int argc, char* argv[])
                 break;
             case 'q':
                 mfu_debug_level = MFU_LOG_NONE;
+                /* since process won't be printed in quiet anyway,
+                 * disable the algorithm to save some overhead */
+                mfu_progress_timeout = 0;    
                 break;
             case 'h':
                 usage = 1;

--- a/src/drm/drm.c
+++ b/src/drm/drm.c
@@ -163,6 +163,9 @@ int main(int argc, char** argv)
                 break;
             case 'q':
                 mfu_debug_level = MFU_LOG_NONE;
+                /* since process won't be printed in quiet anyway,
+                 * disable the algorithm to save some overhead */
+                mfu_progress_timeout = 0;
                 break;
             case 'h':
                 usage = 1;

--- a/src/dstripe/dstripe.c
+++ b/src/dstripe/dstripe.c
@@ -467,6 +467,9 @@ int main(int argc, char* argv[])
                 break;
             case 'q':
                 mfu_debug_level = MFU_LOG_NONE;
+                /* since process won't be printed in quiet anyway,
+                 * disable the algorithm to save some overhead */
+                mfu_progress_timeout = 0;
                 break;
             case 'h':
                 /* display usage */

--- a/src/dsync/dsync.c
+++ b/src/dsync/dsync.c
@@ -2875,6 +2875,9 @@ int main(int argc, char **argv)
         case 'q':
             options.quiet++;
             mfu_debug_level = MFU_LOG_NONE;
+            /* since process won't be printed in quiet anyway,
+             * disable the algorithm to save some overhead */
+            mfu_progress_timeout = 0;
             break;
         case 'h':
         case '?':


### PR DESCRIPTION
Since progress messages will not be printed with --quiet mode of a tool, let's disable them from even happening which could save some MPI overhead.

Signed-off-by: Adam Moody <moody20@llnl.gov>