### PR TITLE
libmfu: do not overwrite block_size during flist_copy

### DIFF
--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -2264,9 +2264,6 @@ int mfu_flist_copy(mfu_flist src_cp_list, int numpaths,
     /* TODO: consider file system striping params here */
     /* hard code some configurables for now */
 
-    /* Set default block size */
-    mfu_copy_opts->block_size = FD_BLOCK_SIZE;
-
     /* allocate buffer to read/write files, aligned on 1MB boundaraies */
     size_t alignment = 1024*1024;
     mfu_copy_opts->block_buf1 = (char*) MFU_MEMALIGN(mfu_copy_opts->block_size, alignment);


### PR DESCRIPTION
The default block_size in mfu_copy_opts will be set when creating a new object.  Someone may override that default, e.g., through the new --blocksize option in dcp.  We do not want to overwrite it during mfu_flist_copy back to the default.

Signed-off-by: Adam Moody <moody20@llnl.gov>