### PR TITLE
mfu_flist_fill

### DIFF
--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -461,6 +461,13 @@ int mfu_flist_hardlink(
     mfu_copy_opts_t* mfu_copy_opts   /* IN - options to be used during copy */
 );
 
+/* fill files in list with data
+ * returns 0 on success -1 on error */
+int mfu_flist_fill(
+    mfu_flist list,                 /* IN - flist providing items */
+    mfu_copy_opts_t* mfu_copy_opts  /* IN - options to be used during fill */
+);
+
 /* allocate a new mfu_walk_opts structure,
  * and set its fields with default values */
 mfu_walk_opts_t* mfu_walk_opts_new(void);


### PR DESCRIPTION
This defines a new mfu_flist_fill() that will write random data to the files in an flist.  It is useful for using an flist to generate a set of files for testing.  We should generalize this to take an argument for the type of fill to be used, e.g., constant byte value, random, etc.