### PR TITLE
docs: fix help to refer to ONLY_SRC and ONLY_DEST

### DIFF
--- a/doc/rst/dcmp.1.rst
+++ b/doc/rst/dcmp.1.rst
@@ -100,17 +100,17 @@ Valid fields are listed below, along with the property of the entry that is chec
 
 Valid conditions for the EXIST field are:
 
-+----------------+------------------------------------------------------------+
-| Condition      | Meaning                                                    |
-+================+============================================================+
-| EXIST=SRC_ONLY | entry exists only in source path                           |
-+----------------+------------------------------------------------------------+
-| EXIST=DST_ONLY | entry exists only in destination path                      |
-+----------------+------------------------------------------------------------+
-| EXIST=DIFFER   | entry exists in either source or destination, but not both |
-+----------------+------------------------------------------------------------+
-| EXIST=COMMON   | entry exists in both source and destination                |
-+----------------+------------------------------------------------------------+
++-----------------+------------------------------------------------------------+
+| Condition       | Meaning                                                    |
++=================+============================================================+
+| EXIST=ONLY_SRC  | entry exists only in source path                           |
++-----------------+------------------------------------------------------------+
+| EXIST=ONLY_DEST | entry exists only in destination path                      |
++-----------------+------------------------------------------------------------+
+| EXIST=DIFFER    | entry exists in either source or destination, but not both |
++-----------------+------------------------------------------------------------+
+| EXIST=COMMON    | entry exists in both source and destination                |
++-----------------+------------------------------------------------------------+
 
 All other fields may only specify the DIFFER and COMMON states.
 
@@ -122,7 +122,7 @@ For example, the following expression reports entries that exist in both source 
 The AND operator binds with higher precedence than the OR operator.
 For example, the following expression matches on entries which either (exist in both source and destination and whose types differ) or (only exist in the source)::
 
-    EXIST=COMMON@TYPE=DIFFER,EXIST=SRC_ONLY
+    EXIST=COMMON@TYPE=DIFFER,EXIST=ONLY_SRC
 
 Some conditions imply others.
 For example, for CONTENT to be considered the same,
@@ -163,11 +163,11 @@ EXAMPLES
 
 3. Write list of entries to outfile1 that are only in src1 or whose names exist in both src1 and src2 but whose types differ:
 
-``mpirun -np 128 dcmp -o EXIST=COMMON@TYPE=DIFFER,EXIST=SRC_ONLY:outfile1 /src1 /src2``
+``mpirun -np 128 dcmp -o EXIST=COMMON@TYPE=DIFFER,EXIST=ONLY_SRC:outfile1 /src1 /src2``
 
 4. Same as above but also write list of entries to outfile2 that exist in either src1 or src2 but not both:
 
-``mpirun -np 128 dcmp -o EXIST=COMMON@TYPE=DIFFER,EXIST=SRC_ONLY:outfile1 -o EXIST=DIFFER:outfile2 /src1 /src2``
+``mpirun -np 128 dcmp -o EXIST=COMMON@TYPE=DIFFER,EXIST=ONLY_SRC:outfile1 -o EXIST=DIFFER:outfile2 /src1 /src2``
 
 SEE ALSO
 --------

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -42,7 +42,7 @@ static void print_usage(void)
     printf("\n");
     printf("Fields: EXIST,TYPE,SIZE,UID,GID,ATIME,MTIME,CTIME,PERM,ACL,CONTENT\n");
     printf("States: DIFFER,COMMON\n");
-    printf("Additional States for EXIST: SRC_ONLY,DEST_ONLY\n");
+    printf("Additional States for EXIST: ONLY_SRC,ONLY_DEST\n");
     printf("\n");
     printf("Example expressions:\n");
     printf("- Entry exists in both source and target and type differs between the two\n");


### PR DESCRIPTION
Documentation had some references to SRC_ONLY, DEST_ONLY, and ONLY_DST:

SRC_ONLY --> ONLY_SRC
DEST_ONLY --> ONLY_DEST
ONLY_DST --> ONLY_DEST