### PR TITLE
mfu: fix invalid call to segmented scan

### DIFF
--- a/src/common/mfu_flist_chunk.c
+++ b/src/common/mfu_flist_chunk.c
@@ -457,6 +457,15 @@ void mfu_file_chunk_list_lor(mfu_flist list, const mfu_file_chunk* head, const i
     /* ltr pointer for the output of the left-to-right-segmented scan */
     int* ltr = (int*) MFU_MALLOC(list_count * sizeof(int));
 
+    /* copy file names into comparison buffer for segmented scan */
+    uint64_t i;
+    const mfu_file_chunk* p = head;
+    for (i = 0; i < list_count; i++) {
+        char* name = keys + max_name * i;
+        strncpy(name, p->name, max_name);
+        p = p->next;
+    }
+
     /* create type and comparison operation for file names for the segmented scan */
     MPI_Datatype keytype = MPI_DATATYPE_NULL;
     DTCMP_Op keyop = DTCMP_OP_NULL;
@@ -498,8 +507,7 @@ void mfu_file_chunk_list_lor(mfu_flist list, const mfu_file_chunk* head, const i
      * going through all files, we then have a count of the number of files we 
      * will report for each rank */
     int disp = 0;
-    uint64_t i;
-    const mfu_file_chunk* p = head;
+    p = head;
     for (i = 0; i < list_count; i++) {
         /* if we have the last byte of the file, we need to send scan result to owner */
         if (p->offset + p->length >= p->file_size) {


### PR DESCRIPTION
In both dcmp and dsync --contents, a segmented scan is used in mfu_file_chunk_list_lor to identify files where different content has been detected.  The scan should segment the input based on a comparison of file names.  However, the file names were not being copied over from the chunk list, meaning the segmented scan was actually operating on an uninitialized set of bytes as returned by malloc.

In dcmp, this bug was discovered in reporting of false positives, i.e., reporting a file as being different when it was not.  A valid difference detected in some file early in the input array could spill into the flags corresponding to files later in the input array, if it so happened that the uninitialized file name happened to be the same.  This bug could also have prevented actual differences from being reported, if the last chunk of a file did not have a difference and if its uninitialized file name happened to be different from the chunk that actually had the difference.

The mfu_file_chunk_list_lor function is also called to determine whether a copy with dcp or dsync was successful for all portions of a file.  This bug could have also led to false positives or false negatives there meaning thinking a file was not copied successfully when it really was or missing detection of a file which failed to copy.

Signed-off-by: Adam Moody <moody20@llnl.gov>