### PR TITLE
dchmod: add algorithm to avoid stat during walk

### DIFF
--- a/doc/rst/dchmod.1.rst
+++ b/doc/rst/dchmod.1.rst
@@ -48,6 +48,11 @@ OPTIONS
    the group on an item that is not owned by the user running the tool.
    With --force, dchmod executes chown/chmod calls on every item.
 
+.. option:: -s, --silent
+
+   Suppress EPERM error messages, which is useful when running dchmod
+   on large directories with files owned by other users.
+
 .. option:: --exclude REGEX
 
    Do not modify items whose full path matches REGEX, processed by

--- a/doc/rst/dchmod.1.rst
+++ b/doc/rst/dchmod.1.rst
@@ -40,6 +40,14 @@ OPTIONS
    as are "rwxX". As with chmod, if no leading letter "ugoa" is provided,
    mode bits are combined with umask to determine the actual mode.
 
+.. option:: -f, --force
+
+   Attempt to change every item.  By default, dchmod avoids unncessary
+   chown and chmod calls, for example trying to change the group
+   on an item that already has the correct group, or trying to change
+   the group on an item that is not owned by the user running the tool.
+   With --force, dchmod executes chown/chmod calls on every item.
+
 .. option:: --exclude REGEX
 
    Do not modify items whose full path matches REGEX, processed by

--- a/doc/rst/libmfu.rst
+++ b/doc/rst/libmfu.rst
@@ -67,14 +67,14 @@ mfu_param_path
 ---------------------------------------
 
 Path names provided by the user on the command line (parameters) are handled
-through the `mfu_param_path <https://github.com/hpc/mpifileutils/blob/master/src/common/mfu_param_path.h>_`
+through the `mfu_param_path <https://github.com/hpc/mpifileutils/blob/master/src/common/mfu_param_path.h>`_
 structure. Such paths may have to be checked for existence and to determine
 their type (file or directory). Additionally, the user may specify many such
 paths through invocations involving shell wildcards, so functions are available
 to check long lists of paths in parallel.
 
 ---------------------------------------
-mfu_io_and_mfu_util
+mfu_io
 ---------------------------------------
 
 The `mfu_io.h <https://github.com/hpc/mpifileutils/blob/master/src/common/mfu_io.h>`_
@@ -82,6 +82,10 @@ functions provide wrappers for many POSIX-IO functions. This is helpful for
 checking error codes in a consistent manner and automating retries on failed
 I/O calls. One should use the wrappers in mfu_io if available, and if not, one
 should consider adding the missing wrapper.
+
+---------------------------------------
+mfu_util
+---------------------------------------
 
 The `mfu_util.h <https://github.com/hpc/mpifileutils/blob/master/src/common/mfu_util.h>`_
 functions provide wrappers for error reporting and memory allocation.

--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -485,9 +485,27 @@ void mfu_flist_mknod(mfu_flist flist);
  * if traceless=1, restore timestamps on parent directories after unlinking children */
 void mfu_flist_unlink(mfu_flist flist, bool traceless);
 
-/* given an input flist, set permissions on items according to perms list,
- * optionally, if usrname != NULL, change owner, or if grname != NULL, change group */
-void mfu_flist_chmod(mfu_flist flist, const char* usrname, const char* grname, const mfu_perms* head);
+typedef struct {
+    bool force; /* always call chmod/chgrp on every item */
+} mfu_chmod_opts_t;
+
+/* return a newly allocated chmod structure */
+mfu_chmod_opts_t* mfu_chmod_opts_new(void);
+
+/* free chmod options allocated from mfu_chmod_opts_new */
+void mfu_chmod_opts_delete(mfu_chmod_opts_t** popts);
+
+/* given an input flist,
+ * change owner on items if usrname != NULL,
+ * change group on items if grname != NULL
+ * set permissions on items according to perms list if head != NULL */
+void mfu_flist_chmod(
+  mfu_flist flist,
+  const char* usrname,
+  const char* grname,
+  const mfu_perms* head,
+  mfu_chmod_opts_t* opts
+);
 
 /* given a source and destination file, update destination metadata
  * to match source if needed, returns 0 on success -1 on error */

--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -486,7 +486,10 @@ void mfu_flist_mknod(mfu_flist flist);
 void mfu_flist_unlink(mfu_flist flist, bool traceless);
 
 typedef struct {
-    bool force; /* always call chmod/chgrp on every item */
+    uid_t uid;    /* user id for item's owner */
+    gid_t gid;    /* group id for item's group */
+    mode_t umask; /* current umask to apply when setting item permissions */
+    bool force;   /* always call chmod/chgrp on every item */
 } mfu_chmod_opts_t;
 
 /* return a newly allocated chmod structure */

--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -486,10 +486,12 @@ void mfu_flist_mknod(mfu_flist flist);
 void mfu_flist_unlink(mfu_flist flist, bool traceless);
 
 typedef struct {
-    uid_t uid;    /* user id for item's owner */
-    gid_t gid;    /* group id for item's group */
-    mode_t umask; /* current umask to apply when setting item permissions */
-    bool force;   /* always call chmod/chgrp on every item */
+    uid_t getuid;  /* result from getuid */
+    uid_t geteuid; /* result from geteuid */
+    uid_t uid;     /* new user id for item's owner, -1 for no change */
+    gid_t gid;     /* new group id for item's group, -1 for no change  */
+    mode_t umask;  /* umask to apply when setting item permissions */
+    bool force;    /* always call chmod/chgrp on every item */
 } mfu_chmod_opts_t;
 
 /* return a newly allocated chmod structure */

--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -492,6 +492,7 @@ typedef struct {
     gid_t gid;     /* new group id for item's group, -1 for no change  */
     mode_t umask;  /* umask to apply when setting item permissions */
     bool force;    /* always call chmod/chgrp on every item */
+    bool silence;  /* avoid printing EPERM errors */
 } mfu_chmod_opts_t;
 
 /* return a newly allocated chmod structure */

--- a/src/common/mfu_flist_chmod.c
+++ b/src/common/mfu_flist_chmod.c
@@ -401,8 +401,8 @@ int mfu_perms_parse(const char* modestr, mfu_perms** p_head)
     /* initialize output parameter */
     *p_head = NULL;
 
-    /* parse the mode string if we got one */
-    if (modestr != NULL) {
+    /* bail out if we didn't get a mode string to parse */
+    if (modestr == NULL) {
         return 0;
     }
 

--- a/src/dchmod/dchmod.c
+++ b/src/dchmod/dchmod.c
@@ -31,6 +31,7 @@ static void print_usage(void)
     printf("  -u, --owner   <user>   - change owner to specified user name or uid\n");
     printf("  -g, --group   <group>  - change group to specified group name or gid\n");
     printf("  -m, --mode    <string> - change mode\n");
+    printf("  -f, --force            - attempt to change every item\n");
     printf("      --exclude <regex>  - exclude a list of files from command\n");
     printf("      --match   <regex>  - match a list of files from command\n");
     printf("  -n, --name             - exclude a list of files from command\n");
@@ -80,6 +81,7 @@ int main(int argc, char** argv)
         {"owner",    1, 0, 'u'},
         {"group",    1, 0, 'g'},
         {"mode",     1, 0, 'm'},
+        {"force",    0, 0, 'f'},
         {"exclude",  1, 0, 'e'},
         {"match",    1, 0, 'a'},
         {"name",     0, 0, 'n'},
@@ -93,7 +95,7 @@ int main(int argc, char** argv)
     int usage = 0;
     while (1) {
         int c = getopt_long(
-                    argc, argv, "i:u:g:m:nvqh",
+                    argc, argv, "i:u:g:m:fnvqh",
                     long_options, &option_index
                 );
 
@@ -113,6 +115,9 @@ int main(int argc, char** argv)
                 break;
             case 'm':
                 modestr = MFU_STRDUP(optarg);
+                break;
+            case 'f':
+                chmod_opts->force = true;
                 break;
             case 'e':
                 regex_exp = MFU_STRDUP(optarg);

--- a/src/dchmod/dchmod.c
+++ b/src/dchmod/dchmod.c
@@ -64,7 +64,6 @@ int main(int argc, char** argv)
     char* groupname = NULL;
     char* modestr   = NULL;
     char* regex_exp = NULL;
-    mfu_perms* head = NULL;
     int walk        = 0;
     int exclude     = 0;
     int name        = 0;
@@ -190,6 +189,7 @@ int main(int argc, char** argv)
     }
 
     /* check that our mode string parses correctly */
+    mfu_perms* head = NULL;
     if (modestr != NULL) {
         int valid = mfu_perms_parse(modestr, &head);
         if (! valid) {
@@ -227,6 +227,9 @@ int main(int argc, char** argv)
     if (walk) {
         /* if in octal mode set use_stat=0 to stat each file on walk */
         if (head != NULL && head->octal && ownername == NULL && groupname == NULL) {
+            walk_opts->use_stat = 0;
+        }
+        if (head == NULL) {
             walk_opts->use_stat = 0;
         }
 

--- a/src/dchmod/dchmod.c
+++ b/src/dchmod/dchmod.c
@@ -32,6 +32,7 @@ static void print_usage(void)
     printf("  -g, --group   <group>  - change group to specified group name or gid\n");
     printf("  -m, --mode    <string> - change mode\n");
     printf("  -f, --force            - attempt to change every item\n");
+    printf("  -s, --silent           - suppress EPERM error messages\n");
     printf("      --exclude <regex>  - exclude a list of files from command\n");
     printf("      --match   <regex>  - match a list of files from command\n");
     printf("  -n, --name             - exclude a list of files from command\n");
@@ -82,6 +83,7 @@ int main(int argc, char** argv)
         {"group",    1, 0, 'g'},
         {"mode",     1, 0, 'm'},
         {"force",    0, 0, 'f'},
+        {"silent",   0, 0, 's'},
         {"exclude",  1, 0, 'e'},
         {"match",    1, 0, 'a'},
         {"name",     0, 0, 'n'},
@@ -95,7 +97,7 @@ int main(int argc, char** argv)
     int usage = 0;
     while (1) {
         int c = getopt_long(
-                    argc, argv, "i:u:g:m:fnvqh",
+                    argc, argv, "i:u:g:m:fsnvqh",
                     long_options, &option_index
                 );
 
@@ -118,6 +120,9 @@ int main(int argc, char** argv)
                 break;
             case 'f':
                 chmod_opts->force = true;
+                break;
+            case 's':
+                chmod_opts->silence = true;
                 break;
             case 'e':
                 regex_exp = MFU_STRDUP(optarg);


### PR DESCRIPTION
* adds new chmod algorithm that avoids calling stat during walk when just setting the group or owner
* bug fix for deleting the linked list of permissions structs
* adds --force option to optionally force chown/chmod to be called on each item
* adds --silent option to avoid printing EPERM errors, which are common when changing files within a directory shared by different users
* adds logic to skip trying to change items whose owner uid is different from effective uid of process (normal users can't do this, privileged users can use --force)
* typos in libmfu documentation
* adds walk rate to walk progress messages