### PR TITLE
dfind: fix -type to allow all file types

### DIFF
--- a/doc/rst/dfind.1.rst
+++ b/doc/rst/dfind.1.rst
@@ -128,11 +128,19 @@ Numeric arguments can be specified as:
    File is of type C:
 
    +---+---------------+
+   | b | block device  |
+   +---+---------------+
+   | c | char device   |
+   +---+---------------+
    | d | directory     |
    +---+---------------+
    | f | regular file  |
    +---+---------------+
    | l | symbolic link |
+   +---+---------------+
+   | p | pipe          |
+   +---+---------------+
+   | s | socket        |
    +---+---------------+
 
 ACTIONS

--- a/src/common/mfu_pred.c
+++ b/src/common/mfu_pred.c
@@ -138,15 +138,11 @@ mfu_pred_times_rel* mfu_pred_relative(const char* str, const mfu_pred_times* t)
 
 int MFU_PRED_TYPE (mfu_flist flist, uint64_t idx, void* arg)
 {
-    mode_t m = *((mode_t*)arg);
-    
+    mode_t type = *((mode_t*)arg);
+
     mode_t mode = (mode_t) mfu_flist_file_get_mode(flist, idx);
 
-    if ((mode & m) == m) {
-        return 1;
-    } else {
-        return 0;
-    }
+    return (mode & S_IFMT) == type;
 }
 
 int MFU_PRED_NAME (mfu_flist flist, uint64_t idx, void* arg)


### PR DESCRIPTION
The check for MFU_PRED_TYPE() incorrectly used the file type as a
mask for the file mode, which would lead to collisions between types
e.g. S_IFREG (0100000) and S_IFLNK (0120000) or S_IFSOCK (0140000).
This would result in "-type f" also finding symlinks.

Properly use S_IFMT as the type mask for the file, and simplify the
return type since it is already a boolean when computed.

Update the man page to report -type can check for all file types.

Signed-off-by: Andreas Dilger <adilger@whamcloud.com>