### PR TITLE
dbcast: replaced functions deprecated in MPI-2.0

### DIFF
--- a/src/dbcast/dbcast.c
+++ b/src/dbcast/dbcast.c
@@ -215,17 +215,17 @@ static int gcs_get_shmem_file(char* file, int len, MPI_Comm comm)
 {
   /* create a new key if we need to */
   if (gcs_shm_file_key == MPI_KEYVAL_INVALID) {
-    MPI_Keyval_create(&gcs_shm_file_attr_copy, &gcs_shm_file_attr_del, &gcs_shm_file_key, (void*)0);
+    MPI_Comm_create_keyval(&gcs_shm_file_attr_copy, &gcs_shm_file_attr_del, &gcs_shm_file_key, (void*)0);
   }
 
   /* fetch attribute value associated with our key from the communicator */
   int flag;
   char* file_tmp = NULL;
-  MPI_Attr_get(comm, gcs_shm_file_key, &file_tmp, &flag);
+  MPI_Comm_get_attr(comm, gcs_shm_file_key, &file_tmp, &flag);
   if (!flag) {
     /* if no value is set, build the filename for this communicator and set the attr value */
     file_tmp = gcs_build_shmem_file(comm);
-    MPI_Attr_put(comm, gcs_shm_file_key, (void*) file_tmp);
+    MPI_Comm_set_attr(comm, gcs_shm_file_key, (void*) file_tmp);
   }
 
   /* check that we got two valid pointers */


### PR DESCRIPTION
Some MPI functions in `dbcast.c` have been deprecated in MPI-2.0, and produce the following warning at compilation time (with Open MPI 4.0.1):
```
/dev/shm/mpifileutils-0.10/src/dbcast/dbcast.c: In function ‘gcs_get_shmem_file’:
/dev/shm/mpifileutils-0.10/src/dbcast/dbcast.c:218:5: warning: ‘MPI_Keyval_create’ is deprecated (declared at /share/software/user/open/openmpi/4.0.1/include/mpi.h:2695): MPI_Keyval_create was deprecated in MPI-2.0; use MPI_Comm_create_keyval instead. [-Wdeprecated-declarations]
     MPI_Keyval_create(&gcs_shm_file_attr_copy, &gcs_shm_file_attr_del, &gcs_shm_file_key, (void*)0);
     ^
/dev/shm/mpifileutils-0.10/src/dbcast/dbcast.c:224:3: warning: ‘MPI_Attr_get’ is deprecated (declared at /share/software/user/open/openmpi/4.0.1/include/mpi.h:2675): MPI_Attr_get was deprecated in MPI-2.0; use MPI_Comm_get_attr instead [-Wdeprecated-declarations]
   MPI_Attr_get(comm, gcs_shm_file_key, &file_tmp, &flag);
   ^
/dev/shm/mpifileutils-0.10/src/dbcast/dbcast.c:228:5: warning: ‘MPI_Attr_put’ is deprecated (declared at /share/software/user/open/openmpi/4.0.1/include/mpi.h:2679): MPI_Attr_put was deprecated in MPI-2.0; use MPI_Comm_set_attr instead [-Wdeprecated-declarations]
     MPI_Attr_put(comm, gcs_shm_file_key, (void*) file_tmp);
     ^
```

This PR replaces the deprecated functions (`MPI_Keyval_create`, `MPI_Attr_get` and `MPI_Attr_put`) by their respective MPI-2.0 equivalent.