### PR TITLE
correct usage message in dfilemaker

### DIFF
--- a/src/dfilemaker/dfilemaker.c
+++ b/src/dfilemaker/dfilemaker.c
@@ -585,7 +585,8 @@ int main(int narg, char** arg)
      *----------------------------------------------*/
     if (narg < 4) {
         if (rank == 0) {
-            printf("Usage: dfilemaker <nitems> <nlevels> <maxflen> [-i seed]\n");
+            printf("Usage: dfilemaker <ntotal> <nlevels> <maxflen> [-i seed]\n");
+            printf("       where ntotal > (levels * (nlevels + 1) /2)\n");
         }
         MPI_Finalize();
         exit(0);
@@ -609,7 +610,7 @@ int main(int narg, char** arg)
     nfiles[0] = ntotal / nsum;
     if (nfiles[0] < 1) {
         if (rank == 0) {
-            printf("nfiles must be greater than nlevels\n");
+            printf("ntotal must be greater than (levels * (nlevels + 1) /2)\n");
         }
         MPI_Finalize();
         exit(0);


### PR DESCRIPTION
Give the user correct guidance about the relationship between
ntotal and nlevels.

The existing output is confusing:
```
bash-4.2$ dfilemaker --help                   
Usage: dfilemaker <nitems> <nlevels> <maxflen> [-i seed]
bash-4.2$ dfilemaker 5 4 3 
nfiles must be greater than nlevels
```

1. It refers to "nfiles" which is not the name of any of the arguments as described by dfilemaker
2. it doesn't indicate how nfiles is calculated

Signed-off-by: Olaf Faaland <faaland1@llnl.gov>