### PR TITLE
mfu: always read full size blocks with O_DIRECT

### DIFF
--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -1584,11 +1584,15 @@ static int mfu_copy_file_normal(
 
     /* write data */
     size_t total_bytes = 0;
-    while(total_bytes <= (size_t)length) {
+    while(total_bytes < (size_t)length) {
         /* determine number of bytes that we
          * can read = max(buf size, remaining chunk) */
         size_t left_to_read = (size_t)length - total_bytes;
         if(left_to_read > buf_size) {
+            left_to_read = buf_size;
+        }
+        if(mfu_copy_opts->synchronous) {
+            /* O_DIRECT requires particular read sizes */
             left_to_read = buf_size;
         }
 

--- a/src/common/mfu_io.c
+++ b/src/common/mfu_io.c
@@ -358,6 +358,9 @@ ssize_t mfu_read(const char* file, int fd, void* buf, size_t size)
             /* read some data */
             n += rc;
             tries = MFU_IO_TRIES;
+
+            /* return, even if we got a short read */
+            return n;
         }
         else if (rc == 0) {
             /* EOF */


### PR DESCRIPTION
When using O_DIRECT, different file systems have different requirements.  In general, one has to use aligned offsets within the file, aligned buffers in memory, and read/write counts that consist of an integral number of blocks.

The read count must always be an integral number of full blocks, even in the case where one knows that the file does not have that much data.  In this case, the read will simply return a short read.

Similarly when writing data, one may have to write past the end of a file by using a write count that exceeds the desired end of the file.  In that case, one must then truncate the file after it has been written.

To complicate matters further, one may be reading from a file system that requires one alignment block size but writing to a different file system that has a different block alignment.  Perhaps that could be solved by computing the minimum common multiple of the two block sizes?  That remains future work.

Signed-off-by: Adam Moody <moody20@llnl.gov>