### PR TITLE
Enhanced dcp error checking

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,6 +1,7 @@
 # todo re-asses if all of these must be *installed*
 LIST(APPEND libmfu_install_headers
   mfu.h
+  mfu_errors.h
   mfu_bz2.h
   mfu_flist.h
   mfu_flist_internal.h

--- a/src/common/mfu_errors.h
+++ b/src/common/mfu_errors.h
@@ -1,0 +1,27 @@
+/* Defines common error codes */
+
+/* enable C++ codes to include this header directly */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef MFU_ERRORS_H
+#define MFU_ERRORS_H
+
+/* Generic error codes */
+#define ERR_INVAL_ARG EINVAL // 22
+
+/* DAOS specific error codes*/
+#define ERR_DAOS            40
+#define ERR_DAOS_INVAL_POOL 41
+#define ERR_DAOS_INVAL_CONT 42
+#define ERR_DAOS_INVAL_SVCL 43
+#define ERR_DAOS_INVAL_PRFX 44
+#define ERR_DAOS_ARG_REQ    45
+
+#endif /* MFU_ERRORS_H */
+
+/* enable C++ codes to include this header directly */
+#ifdef __cplusplus
+} /* extern "C" */
+#endif

--- a/src/common/mfu_errors.h
+++ b/src/common/mfu_errors.h
@@ -13,11 +13,7 @@ extern "C" {
 
 /* DAOS specific error codes*/
 #define ERR_DAOS            40
-#define ERR_DAOS_INVAL_POOL 41
-#define ERR_DAOS_INVAL_CONT 42
-#define ERR_DAOS_INVAL_SVCL 43
-#define ERR_DAOS_INVAL_PRFX 44
-#define ERR_DAOS_ARG_REQ    45
+#define ERR_DAOS_INVAL_PRFX 41
 
 #endif /* MFU_ERRORS_H */
 

--- a/src/common/mfu_errors.h
+++ b/src/common/mfu_errors.h
@@ -8,12 +8,21 @@ extern "C" {
 #ifndef MFU_ERRORS_H
 #define MFU_ERRORS_H
 
-/* Generic error codes */
-#define ERR_INVAL_ARG EINVAL // 22
+/* Convention:
+ * 0-99    -> Generic error codes
+ * 100-199 -> Utility-specific error codes
+ * 200-255 -> Other error codes */
 
-/* DAOS specific error codes*/
-#define ERR_DAOS            40
-#define ERR_DAOS_INVAL_PRFX 41
+/* Generic error codes */
+#define ERR_INVAL_ARG 10
+
+/* DCP-specific error codes */
+#define ERR_DCP      100
+#define ERR_DCP_COPY 101
+
+/* DAOS-specific error codes*/
+#define ERR_DAOS            200
+#define ERR_DAOS_INVAL_PRFX 201
 
 #endif /* MFU_ERRORS_H */
 

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -577,7 +577,7 @@ int main(int argc, char** argv)
     if (rc != 0) {
         mfu_finalize();
         MPI_Finalize();
-        return ERR_INVAL_ARG;
+        return rc;
     }
 
     rc = daos_init();
@@ -593,8 +593,8 @@ int main(int argc, char** argv)
      * prefix since the path is mapped to the root
      * of the container in the DAOS DFS mount */
     if (!daos_uuid_valid(src_pool_uuid) || !daos_uuid_valid(dst_pool_uuid)) {
-        rc =daos_set_paths(rank, argpaths, dfs_prefix, src_pool_uuid, src_cont_uuid,
-            dst_pool_uuid, dst_cont_uuid, mfu_src_file, mfu_dst_file);
+        rc = daos_set_paths(rank, argpaths, dfs_prefix, src_pool_uuid, src_cont_uuid,
+                dst_pool_uuid, dst_cont_uuid, mfu_src_file, mfu_dst_file);
         if (rc != 0) {
             mfu_finalize();
             MPI_Finalize();
@@ -608,7 +608,7 @@ int main(int argc, char** argv)
     if (rc != 0) {
         mfu_finalize();
         MPI_Finalize();
-        return ERR_INVAL_ARG;
+        return rc;
     }
     
     /* check if DAOS source and destination containers are in the same pool */


### PR DESCRIPTION
Error checking for dcp has been enhanced to be more thorough and report specific error codes depending on the failure.
Currently, the new error codes are contained to `dcp.c`.
In the future, it is possible that we could also use error codes in the lower level libraries, but **properly** propagating these errors back to `dcp.c` is a more difficult undertaking which I will save for a later time, as the need arises.

I ran the DAOS functional tests (in progress) against these changes to verify basic functionality for:
- DAOS -> DAOS
- DAOS -> POSIX
- POSIX -> DAOS
- POSIX -> POSIX

### New file: common/mfu_errors.h
- **Please review this for convention**
- Contains some error codes for dcp and DAOS
  - Within the range of 0-255  
- Can be expanded in the future as needed.

### Modified: dcp.c
- Use the new error codes in `mfu_errors.h`
- Better error checking for DAOS
  - Check for required/dependent args
  - Early exit if `dfs_mount` fails
- Print a final message after summary if there were any errors during copy

Closes #363 