### PR TITLE
daos: dcp: enhanced error checking

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,6 +1,7 @@
 # todo re-asses if all of these must be *installed*
 LIST(APPEND libmfu_install_headers
   mfu.h
+  mfu_errors.h
   mfu_bz2.h
   mfu_flist.h
   mfu_flist_internal.h

--- a/src/common/mfu_errors.h
+++ b/src/common/mfu_errors.h
@@ -1,0 +1,32 @@
+/* Defines common error codes */
+
+/* enable C++ codes to include this header directly */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef MFU_ERRORS_H
+#define MFU_ERRORS_H
+
+/* Generic error codes */
+#define MFU_ERR           1000
+#define MFU_ERR_INVAL_ARG 1001
+
+/* DCP-specific error codes */
+#define MFU_ERR_DCP      1100
+#define MFU_ERR_DCP_COPY 1101
+
+/* DAOS-specific error codes*/
+#define MFU_ERR_DAOS            4000
+#define MFU_ERR_DAOS_INVAL_ARG  4001
+
+/* Error macros */
+#define MFU_ERRF "%s(%d)"
+#define MFU_ERRP(rc) "MFU_ERR", rc
+
+#endif /* MFU_ERRORS_H */
+
+/* enable C++ codes to include this header directly */
+#ifdef __cplusplus
+} /* extern "C" */
+#endif

--- a/src/common/mfu_io.c
+++ b/src/common/mfu_io.c
@@ -199,7 +199,7 @@ int mfu_file_access(const char* path, int amode, mfu_file_t* mfu_file)
         int rc = mfu_access(path, amode);
         return rc;
     } else if (mfu_file->type == DAOS) {
-        int rc = daos_access(path, amode);
+        int rc = daos_access(path, amode, mfu_file);
         return rc;
     } else {
         MFU_ABORT(-1, "File type not known: %s type=%d",
@@ -227,11 +227,23 @@ retry:
     return rc;
 }
 
-int daos_access(const char* path, int amode)
+int daos_access(const char* path, int amode, mfu_file_t* mfu_file)
 {
 #ifdef DAOS_SUPPORT
-    /* noop becuase daos have an access call */
-    return 0;
+    char* name     = NULL;
+    char* dir_name = NULL;
+    parse_filename(path, &name, &dir_name);
+    assert(dir_name);
+
+    dfs_obj_t* parent = NULL;
+    int rc = dfs_access(mfu_file->dfs, parent, name, amode);
+    if (rc) {
+        MFU_LOG(MFU_LOG_ERR, "dfs_access %s failed (%d %s)",
+                name, rc, strerror(rc));
+        errno = rc;
+        rc = -1;
+    }
+    return rc;
 #endif
 }
 
@@ -264,7 +276,7 @@ int daos_chmod(const char *path, mode_t mode, mfu_file_t* mfu_file)
     parse_filename(path, &name, &dir_name);
     assert(dir_name);
 
-    dfs_obj_t *parent = NULL;
+    dfs_obj_t* parent = NULL;
     int rc = dfs_lookup(mfu_file->dfs, dir_name, O_RDWR, &parent, NULL, NULL);
     if (parent != NULL) {
         rc = dfs_chmod(mfu_file->dfs, parent, name, mode);
@@ -346,7 +358,7 @@ int daos_stat(const char* path, struct stat* buf, mfu_file_t* mfu_file) {
     parse_filename(path, &name, &dir_name);
     assert(dir_name);
 
-    dfs_obj_t *parent = NULL;
+    dfs_obj_t* parent = NULL;
     int rc;
     if (mfu_file->only_daos) {
         rc = dfs_lookup(mfu_file->dfs, dir_name, O_RDWR, &parent, NULL, NULL);
@@ -564,7 +576,7 @@ void daos_open(const char* file, int flags, mode_t mode, mfu_file_t* mfu_file)
     parse_filename(file, &name, &dir_name);
     assert(dir_name);
 
-    dfs_obj_t *parent = NULL;
+    dfs_obj_t* parent = NULL;
     int rc = dfs_lookup(mfu_file->dfs, dir_name, O_RDWR, &parent, NULL, NULL);
     if (parent != NULL) {
         rc = dfs_open(mfu_file->dfs, parent, name,
@@ -1054,7 +1066,7 @@ int daos_mkdir(const char* dir, mode_t mode, mfu_file_t* mfu_file) {
     assert(dir_name);
 
     /* Need to lookup parent directory in DFS */
-    dfs_obj_t *parent = NULL;
+    dfs_obj_t* parent = NULL;
     int rc = dfs_lookup(mfu_file->dfs, dir_name, O_RDWR, &parent, NULL, NULL);
 
     /* only call mkdir if the dir_name is not the root DFS directory */
@@ -1131,7 +1143,7 @@ retry:
 
 #ifdef DAOS_SUPPORT
 struct dfs_mfu_t {
-    dfs_obj_t *dir;
+    dfs_obj_t* dir;
     struct dirent ents[NUM_DIRENTS];
     daos_anchor_t anchor;
     int num_ents;

--- a/src/common/mfu_io.h
+++ b/src/common/mfu_io.h
@@ -56,7 +56,7 @@ struct stat64;
 /* calls access, and retries a few times if we get EIO or EINTR */
 int mfu_file_access(const char* path, int amode, mfu_file_t* mfu_file);
 int mfu_access(const char* path, int amode);
-int daos_access(const char* path, int amode);
+int daos_access(const char* path, int amode, mfu_file_t* mfu_file);
 
 /* calls lchown, and retries a few times if we get EIO or EINTR */
 int mfu_lchown(const char* path, uid_t owner, gid_t group);

--- a/src/common/mfu_param_path.c
+++ b/src/common/mfu_param_path.c
@@ -406,12 +406,6 @@ void mfu_param_path_check_copy(uint64_t num, const mfu_param_path* paths,
     *flag_valid = 0;
     *flag_copy_into_dir = 0;
 
-    if (mfu_src_file->type == DAOS || mfu_dst_file->type == DAOS) {
-        if (num != 1) {
-            MFU_LOG(MFU_LOG_ERR, "Only one source can be specified when using DAOS");
-        }
-    }
-
     /* need at least two paths to have a shot at being valid */
     if (num < 1 || paths == NULL || destpath == NULL) {
         return;
@@ -426,6 +420,15 @@ void mfu_param_path_check_copy(uint64_t num, const mfu_param_path* paths,
 
     /* just have rank 0 check */
     if(rank == 0) {
+        /* DAOS-specific error checks*/
+        if (mfu_src_file->type == DAOS || mfu_dst_file->type == DAOS) {
+            if (num != 1) {
+                MFU_LOG(MFU_LOG_ERR, "Only one source can be specified when using DAOS");
+                valid = 0;
+                goto bcast;
+            }
+        }
+        
         /* count number of readable source paths */
         uint64_t i;
         int num_readable = 0;

--- a/src/common/mfu_util.c
+++ b/src/common/mfu_util.c
@@ -1123,11 +1123,11 @@ void mfu_stripe_set(const char *path, uint64_t stripe_size, int stripe_count)
 }
 
 /* executes a logical AND operation on flag on all procs on comm,
- * returns 1 if all true and 0 otherwise */
-int mfu_alltrue(int flag, MPI_Comm comm)
+ * returns true if all true and false otherwise */
+bool mfu_alltrue(bool flag, MPI_Comm comm)
 {
     /* check that all processes wrote successfully */
-    int alltrue;
-    MPI_Allreduce(&flag, &alltrue, 1, MPI_INT, MPI_LAND, comm);
+    bool alltrue;
+    MPI_Allreduce(&flag, &alltrue, 1, MPI_C_BOOL, MPI_LAND, comm);
     return alltrue;
 }

--- a/src/common/mfu_util.h
+++ b/src/common/mfu_util.h
@@ -126,13 +126,15 @@ void daos_bcast_handle(
 );
 
 /* connect to DAOS pool, and then open container */
-void daos_connect(
+int daos_connect(
   int rank,
   const char* svc,
   uuid_t pool_uuid,
   uuid_t cont_uuid,
   daos_handle_t* poh,
-  daos_handle_t* coh
+  daos_handle_t* coh,
+  bool connect_pool,
+  bool create_cont
 );
 #endif
 

--- a/src/common/mfu_util.h
+++ b/src/common/mfu_util.h
@@ -288,7 +288,7 @@ void mfu_stripe_set(const char *path, uint64_t stripe_size, int stripe_count);
 
 /* executes a logical AND operation on flag on all procs on comm,
  * returns 1 if all true and 0 otherwise */
-int mfu_alltrue(int flag, MPI_Comm comm);
+bool mfu_alltrue(bool flag, MPI_Comm comm);
 
 #endif /* MFU_UTIL_H */
 

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -22,7 +22,120 @@
 #include "libcircle.h"
 #include "mfu.h"
 
+#include "mfu_errors.h"
+
 #ifdef DAOS_SUPPORT
+int daos_check_args(
+    int rank,
+    char** argpaths,
+    uuid_t src_pool_uuid,
+    uuid_t src_cont_uuid,
+    uuid_t dst_pool_uuid,
+    uuid_t dst_cont_uuid,
+    char* src_svc,
+    char* dst_svc,
+    char* dfs_prefix,
+    int* flag_daos_args)
+{
+    char* src_path = argpaths[0];
+    char* dst_path = argpaths[1];
+
+    bool have_src_path  = src_path != NULL;
+    bool have_dst_path  = dst_path != NULL;
+    bool have_src_pool  = daos_uuid_valid(src_pool_uuid);
+    bool have_src_cont  = daos_uuid_valid(src_cont_uuid);
+    bool have_dst_pool  = daos_uuid_valid(dst_pool_uuid);
+    bool have_dst_cont  = daos_uuid_valid(dst_cont_uuid);
+    bool have_src_svc   = src_svc != NULL;
+    bool have_dst_svc   = dst_svc != NULL;
+    bool have_prefix    = dfs_prefix != NULL;
+
+    /* Determine whether any DAOS arguments are supplied. 
+     * If not, then there is nothing to check. */
+    *flag_daos_args = 0;
+    if (have_src_pool || have_src_cont || have_dst_pool || have_dst_cont
+            || have_src_svc || have_dst_svc || have_prefix) {
+        *flag_daos_args = 1;
+    }
+    else {
+        return 0;
+    } 
+    
+    bool same_pool = false;
+    bool same_cont = false;
+    if (have_src_pool && have_dst_pool 
+            && uuid_compare(src_pool_uuid, dst_pool_uuid) == 0) {
+        same_pool = true;
+        if (have_src_cont && have_dst_cont
+                && uuid_compare(src_cont_uuid, dst_cont_uuid) == 0) {
+            same_cont = true;
+        }
+    }
+
+    int rc = 0;
+
+    if (have_src_cont && !have_src_pool) {
+        if (rank == 0) {
+            MFU_LOG(MFU_LOG_ERR, "Source container requires source pool");
+        }
+        rc = 1;
+    }
+    if (have_src_pool && !have_src_cont) {
+        if (rank == 0) {
+            MFU_LOG(MFU_LOG_ERR, "Source pool requires source container");
+        }
+        rc = 1;
+    }
+    if (have_src_pool && !have_src_svc) {
+        if (rank == 0) {
+            MFU_LOG(MFU_LOG_ERR, "Source pool requires source svcl");
+        }
+        rc = 1;
+    }
+    if (have_dst_cont && !have_dst_pool) {
+        if (rank == 0) {
+            MFU_LOG(MFU_LOG_ERR, "Destination container requires destination pool");
+        }
+        rc = 1;
+    }
+    if (have_dst_pool && !have_dst_svc) {
+        if (rank == 0) {
+            MFU_LOG(MFU_LOG_ERR, "Destination pool requires destination svcl");
+        }
+        rc = 1;
+    }
+    if (have_prefix && !have_src_svc && !have_dst_svc) {
+        if (rank == 0) {
+            MFU_LOG(MFU_LOG_ERR, "Prefix requires source or destination svcl");
+        }
+        rc = 1;
+    }
+
+    /* Containers are using the same pool uuid.
+     * Make sure they are also using the same svc.
+     * This is unlikely to ever happen but we can print an error just in case. */
+    if (same_pool && have_src_svc && have_dst_svc) {
+        if (strcmp(dst_svc, src_svc) != 0) {
+            if (rank == 0) {
+                MFU_LOG(MFU_LOG_ERR, "Using same pool uuid with different svcl's");
+            }
+            rc = 1;
+        }
+    }
+
+    /* Make sure the source and destination are different */
+    if (same_cont && have_src_path && have_dst_path) {
+        if (strcmp(src_path, dst_path) == 0) {
+            if (rank == 0) {
+                 MFU_LOG(MFU_LOG_ERR, "DAOS source is DAOS destination");
+            }
+            rc = 1;
+        }
+    }
+
+    return rc;
+}
+
 static bool daos_check_prefix(char* path, const char* dfs_prefix) 
 {
     bool is_prefix = false;
@@ -38,7 +151,8 @@ static bool daos_check_prefix(char* path, const char* dfs_prefix)
     return is_prefix;
 }
 
-static void daos_set_paths(
+static int daos_set_paths(
+    int rank,
     char** argpaths,
     const char* dfs_prefix,
     uuid_t src_pool_uuid,
@@ -53,67 +167,100 @@ static void daos_set_paths(
     char* src_path = argpaths[0];
     char* dst_path = argpaths[1];
 
+    bool prefix_on_src = false;
+    bool prefix_on_dst = false;
+
     /* find out if a dfs_prefix is being used,
      * if so, then that means that the container
      * is not being copied from the root of the
      * UNS path  */
-    if (dfs_prefix == NULL) {
-        /* assume both are daos paths for UNS, if resolve path
-         * doesn't succeed then set accordingly */
-        struct duns_attr_t src_dattr = {0}; 
-        struct duns_attr_t dst_dattr = {0}; 
-        int src_rc = duns_resolve_path(src_path, &src_dattr);
-        int dst_rc = duns_resolve_path(dst_path, &dst_dattr);
-
-        /* Forward slash is "root" of container to walk
-         * in daos. Cannot walk from Unified namespace
-         * path given /tmp/dsikich/dfs, it is only used
-         * to lookup pool/cont uuids, and tells you
-         * if that path is mapped to pool/cont uuid in
-         * DAOS */
-        if (src_rc == 0 && dst_rc == 0) {
-            mfu_src_file->type = DAOS;
-            mfu_dst_file->type = DAOS;
-            uuid_copy(src_pool_uuid, src_dattr.da_puuid);
-            uuid_copy(src_cont_uuid, src_dattr.da_cuuid);
-            uuid_copy(dst_pool_uuid, dst_dattr.da_puuid);
-            uuid_copy(dst_cont_uuid, dst_dattr.da_cuuid);
-            argpaths[0] = "/";
-            argpaths[1] = "/";
-        } else if (src_rc == 0) { 
-            mfu_src_file->type = DAOS;
-            uuid_copy(src_pool_uuid, src_dattr.da_puuid);
-            uuid_copy(src_cont_uuid, src_dattr.da_cuuid);
-            argpaths[0] = "/";
-        } else if (dst_rc == 0) {
-            mfu_dst_file->type = DAOS;
-            uuid_copy(dst_pool_uuid, dst_dattr.da_puuid);
-            uuid_copy(dst_cont_uuid, dst_dattr.da_cuuid);
-            argpaths[1] = "/";
-        }
-
-        /* set daos io functions for src/dst paths */
-    } else {
-        struct duns_attr_t dattr = {0}; 
+    if (dfs_prefix != NULL) {
+        struct duns_attr_t dattr = {0};
         rc = duns_resolve_path(dfs_prefix, &dattr);
         if (rc != 0) {
-            MFU_LOG(MFU_LOG_ERR, "Failed to resolve DAOS UNS path");
+            MFU_LOG(MFU_LOG_ERR, "Failed to resolve DAOS Prefix UNS path");
+            return 1;
         }
 
-        /* figure out if prefix is on dst or src for 
+        /* figure out if prefix is on dst or src for
          * copying container subsets */
-	if (daos_check_prefix(src_path, dfs_prefix)) {
+        if (daos_check_prefix(src_path, dfs_prefix)) {
             mfu_src_file->type = DAOS;
             uuid_copy(src_pool_uuid, dattr.da_puuid);
             uuid_copy(src_cont_uuid, dattr.da_cuuid);
             argpaths[0] = src_path + strlen(dfs_prefix);
+            prefix_on_src = true;
         } else if (daos_check_prefix(dst_path, dfs_prefix)) {
             mfu_dst_file->type = DAOS;
             uuid_copy(dst_pool_uuid, dattr.da_puuid);
             uuid_copy(dst_cont_uuid, dattr.da_cuuid);
             argpaths[1] = dst_path + strlen(dfs_prefix);
+            prefix_on_dst = true;
+        }
+
+        if (!prefix_on_src && !prefix_on_dst) {
+            MFU_LOG(MFU_LOG_ERR, "DAOS prefix does not match source or destination");
+            return 1;
         }
     }
+
+    /* Forward slash is "root" of container to walk
+     * in daos. Cannot walk from Unified namespace
+     * path given /tmp/dsikich/dfs, it is only used
+     * to lookup pool/cont uuids, and tells you
+     * if that path is mapped to pool/cont uuid in
+     * DAOS 
+     *
+     * For each of the source and destination,
+     * if it is not using a prefix then assume
+     * it is a daos path for UNS. If resolve path
+     * doesn't succeed then it might be a POSIX path */
+    if (!prefix_on_src) {
+        struct duns_attr_t src_dattr = {0};
+        int src_rc = duns_resolve_path(src_path, &src_dattr);
+        
+        if (src_rc == 0) {
+            mfu_src_file->type = DAOS;
+            uuid_copy(src_pool_uuid, src_dattr.da_puuid);
+            uuid_copy(src_cont_uuid, src_dattr.da_cuuid);
+            argpaths[0] = "/";
+        }
+    }
+
+    if (!prefix_on_dst) {
+        struct duns_attr_t dst_dattr = {0};
+        int dst_rc = duns_resolve_path(dst_path, &dst_dattr);
+
+        if (dst_rc == 0) {
+            mfu_dst_file->type = DAOS;
+            uuid_copy(dst_pool_uuid, dst_dattr.da_puuid);
+            uuid_copy(dst_cont_uuid, dst_dattr.da_cuuid);
+            argpaths[1] = "/";
+        }
+    }
+
+    return 0;
+}
+
+/* return 1 if any process has a local error
+ * return 0 otherwise
+ * ignore if no daos args supplied */
+static int daos_any_error(int rank, bool local_daos_error, int flag_daos_args)
+{
+    bool no_error = !local_daos_error;
+    if (flag_daos_args == 0) {
+        no_error = true;
+    }
+
+    if (! mfu_alltrue(no_error, MPI_COMM_WORLD)) {
+        if (rank == 0) {
+           MFU_LOG(MFU_LOG_ERR, "Detected one or more DAOS errors: "
+                   MFU_ERRF, MFU_ERRP(-MFU_ERR_DAOS));
+        }
+        return 1;
+    }
+
+    return 0;
 }
 #endif 
 
@@ -196,6 +343,9 @@ int main(int argc, char** argv)
 {
     /* assume we'll exit with success */
     int rc = 0;
+
+    /* for juggling multiple rc values */
+    int tmp_rc = 0;
 
     /* initialize MPI */
     MPI_Init(&argc, &argv);
@@ -466,24 +616,93 @@ int main(int argc, char** argv)
         usage = 1;
     }
 
+    /* If we need to print the usage
+     * then do so before internal processing */
+    if (usage) {
+        if (rank == 0) {
+            print_usage();
+        }
+        mfu_finalize();
+        MPI_Finalize();
+        return 1;
+    }
+
     char** argpaths = (&argv[optind]);
 
 #ifdef DAOS_SUPPORT
-    rc = daos_init();
+    /* If only the source or destination svc is
+     * given, default the other */
+    if (src_svc != NULL && dst_svc == NULL) {
+        dst_svc = MFU_STRDUP(src_svc);
+    }
+    else if (src_svc == NULL && dst_svc != NULL) {
+        src_svc = MFU_STRDUP(dst_svc);
+    }
 
-    /* TODO: Don't exit and fail if daos fails init,
-     * could just be regular paths */
+    /* Each process keeps track of whether it had any DAOS errors.
+     * If there weren't any daos args, then ignore daos_init errors.
+     * Then, perform a reduction and exit if any process errored. */
+    bool local_daos_error = false;
+    int flag_daos_args;
+
+    /* Make sure we have the required DAOS arguments (if any).
+     * Safe to exit here, since all processes have the same values. */
+    rc = daos_check_args(rank, argpaths, src_pool_uuid, src_cont_uuid,
+            dst_pool_uuid, dst_cont_uuid, src_svc, dst_svc, dfs_prefix,
+            &flag_daos_args);
+    if (rc != 0) {
+        if (rank == 0) {
+            MFU_LOG(MFU_LOG_ERR, "Invalid DAOS args: "
+                    MFU_ERRF, MFU_ERRP(-MFU_ERR_DAOS_INVAL_ARG));
+        }
+        mfu_finalize();
+        MPI_Finalize();
+        return 1;
+    }
+
+    /* For now, track the error.
+     * Later, ignore if no daos args supplied */
+    rc = daos_init();
     if (rc != 0) {
         MFU_LOG(MFU_LOG_ERR, "Failed to initialize daos");
+        local_daos_error = true;
     }
 
     /* Figure out if daos path is the src or dst,
      * using UNS path, then chop off UNS path
      * prefix since the path is mapped to the root
      * of the container in the DAOS DFS mount */
-    if (!daos_uuid_valid(src_pool_uuid) || !daos_uuid_valid(dst_pool_uuid)) {
-        daos_set_paths(argpaths, dfs_prefix, src_pool_uuid, src_cont_uuid,
-            dst_pool_uuid, dst_cont_uuid, mfu_src_file, mfu_dst_file);
+    if (!local_daos_error
+            && (!daos_uuid_valid(src_pool_uuid) || !daos_uuid_valid(dst_pool_uuid))) {
+        rc = daos_set_paths(rank, argpaths, dfs_prefix, src_pool_uuid, src_cont_uuid,
+                dst_pool_uuid, dst_cont_uuid, mfu_src_file, mfu_dst_file);
+        if (rc != 0) {
+            MFU_LOG(MFU_LOG_ERR, "Invalid DAOS args: "
+                    MFU_ERRF, MFU_ERRP(-MFU_ERR_DAOS_INVAL_ARG));
+            local_daos_error = true;
+        }
+    }
+
+    /* Re-check the required DAOS arguments (if any) */
+    if (!local_daos_error) {
+        rc = daos_check_args(rank, argpaths, src_pool_uuid, src_cont_uuid,
+                dst_pool_uuid, dst_cont_uuid, src_svc, dst_svc, dfs_prefix,
+                &flag_daos_args);
+        if (rc != 0) {
+            MFU_LOG(MFU_LOG_ERR, "Invalid DAOS args: "
+                    MFU_ERRF, MFU_ERRP(-MFU_ERR_DAOS_INVAL_ARG));
+            local_daos_error = true;
+        }
+    }
+
+    /* Make sure there weren't any errors before continuing.
+     * Since daos_connect has a collective broadcast.
+     * we have to make sure same_pool below is valid. */
+    if (daos_any_error(rank, local_daos_error, flag_daos_args)) {
+        tmp_rc = daos_fini();
+        mfu_finalize();
+        MPI_Finalize();
+        return 1;
     }
 
     /* check if DAOS source and destination containers are in the same pool */
@@ -492,76 +711,65 @@ int main(int argc, char** argv)
         if (uuid_compare(src_pool_uuid, dst_pool_uuid) == 0) {
             same_pool = true;
         }
-    } 
-
-    /* connect to DAOS source pool if uuid is valid */
-    if (mfu_src_file->type == DAOS) {
-        /* if DAOS source pool uuid is valid, then set source file type to DAOS */
-        daos_connect(rank, src_svc, src_pool_uuid, src_cont_uuid, &src_poh, &src_coh); 
     }
 
-    if (mfu_dst_file->type == DAOS) {
-        if (!same_pool) {
-            /* if DAOS is the source and destination type, and containers are in different pools,
-             * then connect to the second pool */
-            daos_connect(rank, dst_svc, dst_pool_uuid, dst_cont_uuid, &dst_poh, &dst_coh); 
-        } else {
-            /* Containers are using the same pool uuid.
-             * This is unlikely to ever happen but we can print an error just in case */
-            if (dst_svc != NULL && src_svc != NULL) {
-                if (strcmp(dst_svc, src_svc) != 0) {
-                    MFU_LOG(MFU_LOG_ERR, "Using same pool uuid with different svcl's");
-                    return 1;
-                }
-            }
-            if (rank == 0) {
-                /* create container in same pool */
-                daos_cont_info_t co_info;
-                rc = daos_cont_open(src_poh, dst_cont_uuid, DAOS_COO_RW, &dst_coh, &co_info, NULL);
-
-                /* If NOEXIST we create it */
-                if (rc != 0) {
-                    /* create the container */
-                    uuid_t cuuid;
-                    rc = dfs_cont_create(src_poh, cuuid, NULL, NULL, NULL);
-                    if (rc != 0) {
-                        MFU_LOG(MFU_LOG_ERR, "Failed to create DFS2 container");
-                    }
-
-                    /* try to open it again */
-                    rc = daos_cont_open(src_poh, cuuid, DAOS_COO_RW, &dst_coh, &co_info, NULL);
-                    if (rc != 0) {
-                        MFU_LOG(MFU_LOG_ERR, "Failed to open DFS2 container");
-                    }
-                }
-            }
-
-            /* broadcast container handle from rank 0 */
-            daos_bcast_handle(rank, &dst_coh, &src_poh, CONT_HANDLE);
+    /* connect to DAOS source pool if uuid is valid */
+    if (!local_daos_error && mfu_src_file->type == DAOS) {
+        /* Open pool connection, but do not create container if non-existent */
+        rc = daos_connect(rank, src_svc, src_pool_uuid, src_cont_uuid, &src_poh, &src_coh, true, false);
+        if (rc != 0) {
+            /* rc from daos_connect is collective */
+            local_daos_error = true;
         }
     }
 
-    if (mfu_src_file->type == DAOS) {
+    /* If the source and destination are in the same pool,
+     * then open the container in that pool.
+     * Otherwise, connect to the second pool and open the container */
+    if (!local_daos_error && mfu_dst_file->type == DAOS) {
+        if (same_pool) {
+            /* Don't reconnect to pool, but do create container if non-existent */
+            rc = daos_connect(rank, dst_svc, dst_pool_uuid, dst_cont_uuid, &src_poh, &dst_coh, false, true);
+        } else {
+            /* Open pool connection, and create container if non-existent */
+            rc = daos_connect(rank, dst_svc, dst_pool_uuid, dst_cont_uuid, &dst_poh, &dst_coh, true, true); 
+        }
+        if (rc != 0) {
+            /* rc from daos_connect is collective */
+            local_daos_error = true;
+        }
+    }
+
+    if (!local_daos_error && mfu_src_file->type == DAOS) {
         /* DFS is mounted for the source container */
         rc = dfs_mount(src_poh, src_coh, O_RDWR, &dfs1);
         if (rc != 0) {
-            MFU_LOG(MFU_LOG_ERR, "Failed to mount DAOS filesystem (DFS)");
+            MFU_LOG(MFU_LOG_ERR, "Failed to mount DAOS filesystem (DFS): "
+                    MFU_ERRF, MFU_ERRP(-MFU_ERR_DAOS));
+            local_daos_error = true;
         }
     }
 
-    if (mfu_dst_file->type == DAOS) {
+    if (!local_daos_error && mfu_dst_file->type == DAOS) {
         /* DFS is mounted for the destination container */
         if (same_pool) {
             rc = dfs_mount(src_poh, dst_coh, O_RDWR, &dfs2);
-            if (rc != 0) {
-                MFU_LOG(MFU_LOG_ERR, "Failed to mount DAOS filesystem (DFS)");
-            }
         } else {
             rc = dfs_mount(dst_poh, dst_coh, O_RDWR, &dfs2);
-            if (rc != 0) {
-                MFU_LOG(MFU_LOG_ERR, "Failed to mount DAOS filesystem (DFS)");
-            }
         }
+        if (rc != 0) {
+            MFU_LOG(MFU_LOG_ERR, "Failed to mount DAOS filesystem (DFS): "
+                    MFU_ERRF, MFU_ERRP(-MFU_ERR_DAOS));
+            local_daos_error = true;
+        }
+    }
+
+    /* Exit if any process had a daos error */
+    if (daos_any_error(rank, local_daos_error, flag_daos_args)) {
+        tmp_rc = daos_fini();
+        mfu_finalize();
+        MPI_Finalize();
+        return 1;
     }
 
     /* set source and destination files to address of their
@@ -593,13 +801,10 @@ int main(int argc, char** argv)
         numpaths_src = numpaths - 1;
     }
 
-    if (usage || numpaths_src == 0) {
+    if (numpaths_src == 0) {
         if(rank == 0) {
-            if (usage != 1) {
-                MFU_LOG(MFU_LOG_ERR, "A source and destination path is needed");
-            } else {
-                print_usage();
-            }
+            MFU_LOG(MFU_LOG_ERR, "A source and destination path is needed: "
+                    MFU_ERRF, MFU_ERRP(-MFU_ERR_INVAL_ARG));
         }
 
         mfu_param_path_free_all(numpaths, paths);
@@ -615,12 +820,13 @@ int main(int argc, char** argv)
     /* Parse the source and destination paths. */
     int valid, copy_into_dir;
     mfu_param_path_check_copy(numpaths_src, paths, destpath, mfu_src_file, mfu_dst_file, &valid, &copy_into_dir);
-    mfu_copy_opts->copy_into_dir = copy_into_dir; 
+    mfu_copy_opts->copy_into_dir = copy_into_dir;
 
     /* exit job if we found a problem */
     if (!valid) {
         if(rank == 0) {
-            MFU_LOG(MFU_LOG_ERR, "Invalid src/dest paths provided. Exiting run.\n");
+            MFU_LOG(MFU_LOG_ERR, "Invalid src/dest paths provided. Exiting run: "
+                    MFU_ERRF, MFU_ERRP(-MFU_ERR_INVAL_ARG));
         }
         mfu_param_path_free_all(numpaths, paths);
         mfu_free(&paths);
@@ -649,9 +855,9 @@ int main(int argc, char** argv)
     }
 
     /* copy flist into destination */ 
-    int tmp_rc = mfu_flist_copy(flist, numpaths_src, paths,
-                                destpath, mfu_copy_opts, mfu_src_file,
-                                mfu_dst_file);
+    tmp_rc = mfu_flist_copy(flist, numpaths_src, paths,
+                            destpath, mfu_copy_opts, mfu_src_file,
+                            mfu_dst_file);
     if (tmp_rc < 0) {
         /* hit some sort of error during copy */
         rc = 1;
@@ -678,43 +884,43 @@ int main(int argc, char** argv)
     /* DAOS: unmount DFS, and close containers and pools */
 #ifdef DAOS_SUPPORT
     if (mfu_src_file->type == DAOS) {
-        rc = dfs_umount(mfu_src_file->dfs);
+        tmp_rc = dfs_umount(mfu_src_file->dfs);
         MPI_Barrier(MPI_COMM_WORLD);
-        if (rc != 0) {
-            MFU_LOG(MFU_LOG_ERR, "Failed to mount DFS namespace");
+        if (tmp_rc != 0) {
+            MFU_LOG(MFU_LOG_ERR, "Failed to umount DFS namespace");
         }
-        rc = daos_cont_close(src_coh, NULL);
+        tmp_rc = daos_cont_close(src_coh, NULL);
         MPI_Barrier(MPI_COMM_WORLD);
-        if (rc != 0) {
+        if (tmp_rc != 0) {
             MFU_LOG(MFU_LOG_ERR, "Failed to close container (%d)", rc);
         }
     }
 
     if (mfu_dst_file->type == DAOS) {
-        rc = dfs_umount(mfu_dst_file->dfs);
+        tmp_rc = dfs_umount(mfu_dst_file->dfs);
         MPI_Barrier(MPI_COMM_WORLD);
-        if (rc != 0) {
+        if (tmp_rc != 0) {
             MFU_LOG(MFU_LOG_ERR, "Failed unmount DFS namespace");
         }
-        rc = daos_cont_close(dst_coh, NULL);
+        tmp_rc = daos_cont_close(dst_coh, NULL);
         MPI_Barrier(MPI_COMM_WORLD);
-        if (rc != 0) {
+        if (tmp_rc != 0) {
             MFU_LOG(MFU_LOG_ERR, "Failed to close container (%d)", rc);
         }
     }
 
     if (mfu_src_file->type == DAOS) {
-        rc = daos_pool_disconnect(src_poh, NULL);
+        tmp_rc = daos_pool_disconnect(src_poh, NULL);
         MPI_Barrier(MPI_COMM_WORLD);
-        if (rc != 0) {
+        if (tmp_rc != 0) {
             MFU_LOG(MFU_LOG_ERR, "Failed to disconnect from source pool");
         }
     }
 
     if (mfu_dst_file->type == DAOS && !same_pool) {
-        rc = daos_pool_disconnect(dst_poh, NULL);
+        tmp_rc = daos_pool_disconnect(dst_poh, NULL);
         MPI_Barrier(MPI_COMM_WORLD);
-        if (rc != 0) {
+        if (tmp_rc != 0) {
             MFU_LOG(MFU_LOG_ERR, "Failed to disconnect from destination pool");
         }
     }
@@ -724,9 +930,17 @@ int main(int argc, char** argv)
     mfu_file_delete(&mfu_src_file);
     mfu_file_delete(&mfu_dst_file);
 
+    /* Alert the user if there were copy errors */
+    if (rc != 0) {
+        if (rank == 0) {
+            MFU_LOG(MFU_LOG_ERR, "One or more errors were detected while copying: "
+                    MFU_ERRF, MFU_ERRP(-MFU_ERR_DCP_COPY));
+        }
+    }
+
 #ifdef DAOS_SUPPORT
     /* finalize daos */
-    rc = daos_fini();
+    tmp_rc = daos_fini();
 #endif
 
     mfu_finalize();
@@ -734,5 +948,8 @@ int main(int argc, char** argv)
     /* shut down MPI */
     MPI_Finalize();
 
+    if (rc != 0) {
+        return 1;
+    }
     return 0;
 }


### PR DESCRIPTION
My branch deviated a bit from my previous PR, I had many small commits, and git wasn't cooperating, so I'm just creating a new PR entirely.

**common/mfu_errors.h**
- New file
- Defines some generic error codes, codes for dcp, and codes for DAOS
  - Ranges are in the 1000s, 1100s, and 4000s
- Defines MFU_ERRF and MFU_ERRP for printing the error codes.
  - Formatted as: MFU_ERR(#)
  - Could be improved in the future to print the"string" error code instead of just MFU_ERR
    - DAOS has something similar to this

**common/mfu_io**
- Defined daos_access

**common/mfu_param_path.c**
- mfu_param_path_check_copy - Return on DAOS error

**common/mfu_util**
- daos_connect
  - Added flag for whether or not to connect to pool
  - Added flag for whether or not to auto-create the destination container
    - No longer creates the source container automatically
  - These flags allow a centralized way to capture errors. I.e. only one bcast is needed for pool connection, cont connection, cont creation
  - Rank 0 now tracks and broadcasts any errors before trying to share the handles
  - Function returns an error

**dcp/dcp.c**
- Use the new error codes from mfu_error.h
- DAOS errors are generally handled more precisely
  - Each process tracks local errors, and stops making DAOS calls once it has run into an error
  - Allreduce on local DAOS errors, so all processes will know to exit
  - Check DAOS arguments before trying to make DAOS calls
  - Refactored daos_connect calls to better capture errors and exit if found
  - More gracefully handle a failed daos_init call
  - Exit if DAOS source is DAOS destination

closes #363 
closes #361
closes #370