### PR TITLE
daos: daos_mknod implementation

### DIFF
--- a/src/common/mfu_io.c
+++ b/src/common/mfu_io.c
@@ -449,10 +449,61 @@ retry:
     return rc;
 }
 
-/* use a noop, daos does not have a mknod function */
+/* emulates mknod with dfs_open, dfs_release */
 int daos_mknod(const char* path, mode_t mode, dev_t dev, mfu_file_t* mfu_file)
 {
-    return 0;
+#ifdef DAOS_SUPPORT
+    /* Only regular files are supported at this time */
+    mode_t dfs_mode = mode | S_IFREG;
+    mode_t filetype = dfs_mode & S_IFMT;
+    if (filetype != S_IFREG) {
+        MFU_LOG(MFU_LOG_ERR, "Invalid entry type (not a file)");
+        errno = EINVAL;
+        return -1;
+    }
+
+    char* name     = NULL;
+    char* dir_name = NULL;
+    parse_filename(path, &name, &dir_name);
+    assert(dir_name);
+
+    dfs_obj_t* parent = NULL;
+    int rc = dfs_lookup(mfu_file->dfs, dir_name, O_RDWR, &parent, NULL, NULL);
+    if (parent == NULL) {
+        MFU_LOG(MFU_LOG_ERR, "dfs_lookup %s failed", dir_name);
+        errno = ENOENT;
+        rc = -1;
+    }
+    else {
+        /* create regular file */
+        rc = dfs_open(mfu_file->dfs, parent, name,
+                      dfs_mode, O_CREAT,
+                      0, 0, NULL, &(mfu_file->obj));
+        if (rc) {
+            MFU_LOG(MFU_LOG_ERR, "dfs_open %s failed (%d %s)",
+                    name, rc, strerror(rc));
+            errno = rc;
+            rc = -1;
+        }
+        else {
+            /* close the file */
+            rc = dfs_release(mfu_file->obj);
+            if (rc) {
+                MFU_LOG(MFU_LOG_ERR, "dfs_release %s failed (%d %s)",
+                        path, rc, strerror(rc));
+                errno = rc;
+                rc = -1;
+            }
+        }
+        /* close the parent, ignoring errors since they have no direct impact */
+        dfs_release(parent);
+    }
+
+    mfu_free(&name);
+    mfu_free(&dir_name);
+
+    return rc;
+#endif
 }
 
 int mfu_mknod(const char* path, mode_t mode, dev_t dev)
@@ -581,9 +632,18 @@ retry:
 /*****************************
  * Files
  ****************************/
-void daos_open(const char* file, int flags, mode_t mode, mfu_file_t* mfu_file)
+int daos_open(const char* file, int flags, mode_t mode, mfu_file_t* mfu_file)
 {
 #ifdef DAOS_SUPPORT
+    /* Only regular files are supported at this time */
+    mode_t dfs_mode = mode | S_IFREG;
+    mode_t filetype = dfs_mode & S_IFMT;
+    if (filetype != S_IFREG) {
+        MFU_LOG(MFU_LOG_ERR, "Invalid entry type (not a file)");
+        errno = EINVAL;
+        return -1;
+    }
+
     char* name     = NULL;
     char* dir_name = NULL;
     parse_filename(file, &name, &dir_name);
@@ -593,7 +653,7 @@ void daos_open(const char* file, int flags, mode_t mode, mfu_file_t* mfu_file)
     int rc = dfs_lookup(mfu_file->dfs, dir_name, O_RDWR, &parent, NULL, NULL);
     if (parent != NULL) {
         rc = dfs_open(mfu_file->dfs, parent, name,
-                      S_IFREG | mode, flags,
+                      dfs_mode, flags,
                       0, 0, NULL, &(mfu_file->obj));
         if (rc) {
             MFU_LOG(MFU_LOG_ERR, "dfs_open %s failed (%d %s)",
@@ -609,6 +669,8 @@ void daos_open(const char* file, int flags, mode_t mode, mfu_file_t* mfu_file)
 
     mfu_free(&name);
     mfu_free(&dir_name);
+
+    return rc;
 #endif
 }
 

--- a/src/common/mfu_io.h
+++ b/src/common/mfu_io.h
@@ -114,7 +114,7 @@ int mfu_symlink(const char* oldpath, const char* newpath);
 
 /* open file with specified flags and mode, retry open a few times on failure */
 void mfu_file_open(const char* file, int flags, mfu_file_t* mfu_file, ...);
-void daos_open(const char* file, int flags, mode_t mode, mfu_file_t* mfu_file);
+int daos_open(const char* file, int flags, mode_t mode, mfu_file_t* mfu_file);
 int mfu_open(const char* file, int flags, ...);
 
 /* close file */


### PR DESCRIPTION
daos_mknod is implemented in two steps:
1. dfs_open(..., O_CREATE,...)
2. dfs_release(...)

This works for regular files only at this time.

closes #377 
closes #353 

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>