### PR TITLE
daos: robust enhancements

### DIFF
--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -2053,7 +2053,7 @@ static int mfu_copy_files(mfu_flist list, uint64_t chunk_size,
                     rc = -1;
 #if 0
                     /* delete destination file */
-                    int unlink_rc = mfu_unlink(dest);
+                    int unlink_rc = mfu_file_unlink(dest, mfu_dst_file);
                     if (unlink_rc != 0) {
                         MFU_LOG(MFU_LOG_ERR, "Failed to unlink `%s' (errno=%d %s)",
                                   name, errno, strerror(errno)

--- a/src/common/mfu_flist_walk.c
+++ b/src/common/mfu_flist_walk.c
@@ -354,7 +354,7 @@ static void walk_readdir_process_dir(const char* dir, CIRCLE_handle* handle)
                         /* unlink files here if remove option is on,
                          * and dtype is known without a stat */
                         if (REMOVE_FILES && (entry->d_type != DT_DIR)) {
-                            mfu_unlink(newpath);
+                            mfu_file_unlink(newpath, mfu_file);
                         } else {
                             /* we can read object type from directory entry */
                             have_mode = 1;
@@ -372,7 +372,7 @@ static void walk_readdir_process_dir(const char* dir, CIRCLE_handle* handle)
                             /* unlink files here if remove option is on,
                              * and stat was necessary to get type */
                             if (REMOVE_FILES && !S_ISDIR(st.st_mode)) {
-                                mfu_unlink(newpath);
+                                mfu_file_unlink(newpath, mfu_file);
                             } else {
                                 mfu_flist_insert_stat(CURRENT_LIST, newpath, mode, &st);
                             }
@@ -527,7 +527,7 @@ static void walk_stat_process(CIRCLE_handle* handle)
     /* TODO: filter items by stat info */
 
     if (REMOVE_FILES && !S_ISDIR(st.st_mode)) {
-        mfu_unlink(path);
+        mfu_file_unlink(path, mfu_file);
     } else {
         /* record info for item in list */
         mfu_flist_insert_stat(CURRENT_LIST, path, st.st_mode, &st);

--- a/src/common/mfu_io.c
+++ b/src/common/mfu_io.c
@@ -249,6 +249,8 @@ int daos_access(const char* path, int amode, mfu_file_t* mfu_file)
     mfu_free(&dir_name);
     
     return rc;
+#else
+    return 0;
 #endif
 }
 
@@ -303,6 +305,8 @@ int daos_chmod(const char *path, mode_t mode, mfu_file_t* mfu_file)
     mfu_free(&dir_name);
 
     return rc;
+#else
+    return 0;
 #endif
 }
 
@@ -400,6 +404,8 @@ int daos_stat(const char* path, struct stat* buf, mfu_file_t* mfu_file)
     mfu_free(&dir_name);
 
     return rc;
+#else
+    return 0;
 #endif
 }
 
@@ -512,6 +518,8 @@ int daos_mknod(const char* path, mode_t mode, dev_t dev, mfu_file_t* mfu_file)
     mfu_free(&dir_name);
 
     return rc;
+#else
+    return 0;
 #endif
 }
 
@@ -682,6 +690,8 @@ int daos_open(const char* file, int flags, mode_t mode, mfu_file_t* mfu_file)
     mfu_free(&dir_name);
 
     return rc;
+#else
+    return 0;
 #endif
 }
 
@@ -775,6 +785,8 @@ int daos_close(const char* file, mfu_file_t* mfu_file)
         rc = -1;
     }
     return rc;
+#else
+    return 0;
 #endif
 }
 
@@ -828,6 +840,8 @@ int daos_lseek(const char* file, mfu_file_t* mfu_file, off_t pos, int whence)
     } else {
         MFU_ABORT(-1, "daos_lseek whence type not known: %d", whence);
     }
+    return 0;
+#else
     return 0;
 #endif
 }
@@ -908,6 +922,8 @@ ssize_t daos_read(const char* file, void* buf, size_t size, mfu_file_t* mfu_file
     mfu_file->offset += (daos_off_t)got_size;
 
     return (ssize_t)got_size;
+#else
+    return (ssize_t)0;
 #endif
 }
 
@@ -1024,6 +1040,8 @@ ssize_t daos_write(const char* file, const void* buf, size_t size, mfu_file_t* m
     mfu_file->offset += (daos_off_t)size;
 
     return (ssize_t)size;
+#else
+    return (ssize_t)0;
 #endif
 }
 
@@ -1066,6 +1084,8 @@ ssize_t daos_pread(const char* file, void* buf, size_t size, off_t offset, mfu_f
     }
 
     return (ssize_t)got_size;
+#else
+    return (ssize_t)0;
 #endif
 }
 
@@ -1163,6 +1183,8 @@ ssize_t daos_pwrite(const char* file, const void* buf, size_t size, off_t offset
     }
 
     return (ssize_t)size;
+#else
+    return (ssize_t)0;
 #endif
 }
 
@@ -1200,6 +1222,8 @@ int daos_ftruncate(mfu_file_t* mfu_file, off_t length)
         rc = -1;
     }
     return rc;
+#else
+    return 0;
 #endif
 }
 
@@ -1295,7 +1319,9 @@ int daos_unlink(const char* file, mfu_file_t* mfu_file)
     mfu_free(&name);
     mfu_free(&dir_name);
 
-    return rc; 
+    return rc;
+#else
+    return 0;
 #endif
 }
 
@@ -1394,6 +1420,8 @@ int daos_mkdir(const char* dir, mode_t mode, mfu_file_t* mfu_file)
     mfu_free(&dir_name);
 
     return rc;
+#else
+    return 0;
 #endif
 }
 
@@ -1480,6 +1508,8 @@ DIR* daos_opendir(const char* dir, mfu_file_t* mfu_file)
         return NULL;
     }
     return (DIR *)dirp;
+#else
+    return NULL;
 #endif
 }
 
@@ -1532,6 +1562,8 @@ int daos_closedir(DIR* _dirp, mfu_file_t* mfu_file)
     }
     free(dirp);
     return rc;
+#else
+    return 0;
 #endif
 }
 
@@ -1599,6 +1631,8 @@ struct dirent* daos_readdir(DIR* _dirp, mfu_file_t* mfu_file)
 ret:
     dirp->num_ents--;
     return &dirp->ents[dirp->num_ents];
+#else
+    return NULL;
 #endif
 }
 

--- a/src/common/mfu_io.h
+++ b/src/common/mfu_io.h
@@ -83,7 +83,6 @@ int daos_stat(const char* path, struct stat* buf, mfu_file_t* mfu_file);
 
 /* call mknod, retry a few times on EINTR or EIO */
 int mfu_file_mknod(const char* path, mode_t mode, dev_t dev, mfu_file_t* mfu_file);
-/* just a noop, since there is no daos_mknod */
 int daos_mknod(const char* path, mode_t mode, dev_t dev, mfu_file_t* mfu_file);
 int mfu_mknod(const char* path, mode_t mode, dev_t dev);
 
@@ -157,6 +156,8 @@ int daos_ftruncate(mfu_file_t* mfu_file, off_t length);
 int mfu_ftruncate(int fd, off_t length);
 
 /* delete a file */
+int mfu_file_unlink(const char* file, mfu_file_t* mfu_file);
+int daos_unlink(const char* file, mfu_file_t* mfu_file);
 int mfu_unlink(const char* file);
 
 /* force flush of written data */


### PR DESCRIPTION
Three commits, three issues.

>**daos: mfu_file_unlink and daos_unlink implementation**
>Added implementation for mfu_file_unlink and daos_unlink.
>Updated mfu_flist_copy.c and mfu_flist_walk.c to use the
>new mfu_file_unlink.
>
>The following files still have references to mfu_unlink,
>but I don't believe that can/should be updated:
>mfu_flist_remove.c
>dbcast.c
>dreln.c
>copy.c
>dbz2.c

closes #352 


>**daos: mfu_io: add dfs_release for each dfs_lookup**
>Each daos_* function that uses dfs_lookup now also
>has a corresponding dfs_release, except for "open"
>functions, since this is handled in "close".

One exception: calls made in `lookup_insert_dir` do not have a corresponding `dfs_release`, since this will require more effort to fix. New issue #384 created to handle this.

closes #382 


>**daos: mfu_io: return 0 or NULL if not DAOS_SUPPORT**
>For daos_* functions, when DAOS_SUPPORT is not defined,
>the functions will just return 0 or NULL to alleviate
>compiler warnings/errors.

I opted for the `#else` approach here, since I felt it was more explicit and less error prone than the `int rc = 0; #ifdef DAOS_SUPPORT...#endif return rc`
 approach.

closes #383 