### PR TITLE
mfu: support aarch64

### DIFF
--- a/src/common/mfu_flist_walk.c
+++ b/src/common/mfu_flist_walk.c
@@ -161,6 +161,9 @@ static void walk_getdents_process_dir(const char* dir, CIRCLE_handle* handle)
         return;
     }
 
+#if !defined(SYS_getdents) && defined(SYS_getdents64)
+#define SYS_getdents SYS_getdents64
+#endif
     /* Read all directory entries */
     while (1) {
         /* execute system call to get block of directory entries */


### PR DESCRIPTION
aarch64 kernel is not found SYS_getdents.
If SYS_getdents is not defined, use sys_getdents64.

Signed-off-by: Toyohisa Kameyama <kameyama@riken.jp>