### PR TITLE
daos: enhance use of lookup hash

### DIFF
--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -3171,10 +3171,10 @@ mfu_file_t* mfu_file_new(void)
     mfu_file_t* mfile = (mfu_file_t*) MFU_MALLOC(sizeof(mfu_file_t));
     mfile->type       = POSIX;
     mfile->fd         = -1;
-    mfile->only_daos  = false;
 #ifdef DAOS_SUPPORT
     mfile->obj        = NULL;
     mfile->dfs        = NULL;
+    mfile->dfs_hash   = NULL;
 #endif
     return mfile;
 }

--- a/src/common/mfu_param_path.h
+++ b/src/common/mfu_param_path.h
@@ -54,14 +54,14 @@ typedef struct mfu_param_path_t {
 
 /* options passed to I/O functions that tell them which backend filesystem to use */
 typedef struct {
-    enum        {POSIX, DAOS} type;
-    int         fd;
-    bool        only_daos;
+    enum                 {POSIX, DAOS} type;
+    int                  fd;
 #ifdef DAOS_SUPPORT
     /* DAOS specific variables for I/O */
-    daos_off_t   offset;
-    dfs_obj_t*   obj;
-    dfs_t*       dfs;
+    daos_off_t           offset;
+    dfs_obj_t*           obj;
+    dfs_t*               dfs;
+    struct d_hash_table* dfs_hash;
 #endif
 } mfu_file_t;
 

--- a/src/common/mfu_util.h
+++ b/src/common/mfu_util.h
@@ -136,6 +136,19 @@ int daos_connect(
   bool connect_pool,
   bool create_cont
 );
+
+/* Mount DAOS dfs */
+int daos_mount(
+  mfu_file_t* mfu_file,
+  daos_handle_t* poh,
+  daos_handle_t* coh
+);
+
+/* Unmount DAOS dfs.
+ * Cleanup up hash */
+int daos_umount(
+  mfu_file_t* mfu_file
+);
 #endif
 
 /* initialize mfu library,


### PR DESCRIPTION
**_Question_** @adammoody
As the DAOS-related code grows, would you prefer we move DAOS-specific functions to some new `daos_util.[h,c]`? E.g. hash functions, setup functions.
(But keep the `daos_*` IO functions in `mfu_io.c`)

lookup_insert_dir and associated functions have been
refactored and expanded.

*mfu_param_path.h*
- Added dfs_hash to mfu_file.
- Removed only_daos from mfu_file, since it is no longer needed

*Naming convention*
- Changed mfu_* to daos_* since they are only used by DAOS.
- Changed lookup_insert_dir to daos_lookup_hash.

*daos_lookup_hash and associated functions*
- Gets the hash from mfu_file instead of a global.
- Uses a pointer to the name instead of static allocation,
  which saves space.
- Updated error messages to use MFU_LOG instead of stderr directly.
- Added a _new and _delete function for the object handle struct.
- Properly deallocate and free each entry.

*daos_ IO functions*
With the excpetion of daos_opendir and daos_closedir,
all daos_ IO functions now use daos_hash_lookup to
get directory entries.

*mfu_util*
- Added daos_mount as a wrapper for dfs_mount.
- Added daos_umount as a wrapper for dfs_umount.
  This also destroys the hash.

*dcp.c*
Now uses the new daos_mount and daos_umount functions.

closes #384 
closes #387 