### PR TITLE
memory leaks and DAOS enhancements

### DIFF
--- a/src/common/mfu_flist_chunk.c
+++ b/src/common/mfu_flist_chunk.c
@@ -393,6 +393,44 @@ mfu_file_chunk* mfu_file_chunk_list_alloc(mfu_flist list, uint64_t chunk_size)
         tail = p;
     }
 
+    /* free the send and receive flag arrays */
+    mfu_free(&sendlist);
+    mfu_free(&recvlist);
+
+    /* free the linked lists, packed send buffers, and related arrays */
+    for (int i = 0; i < send_ranks; i++) {
+        mfu_free(&sendbufs[i]);
+
+        /* free the element linked list for each rank.
+         * Do not free elem->name because it is needed by the mfu_flist entry. */
+        mfu_file_chunk* elem = heads[i];
+        mfu_file_chunk* tmp;
+        while (elem != NULL) {
+            tmp = elem;
+            elem = elem->next;
+            mfu_free(&tmp);
+        }
+    }
+    mfu_free(&heads);
+    mfu_free(&tails);
+    mfu_free(&counts);
+    mfu_free(&bytes);
+    mfu_free(&sendbufs);
+
+    /* free the array for ranks recevied from */
+    mfu_free(&recvranklist);
+
+    /* free the request and status messages */
+    mfu_free(&request);
+    mfu_free(&status);
+    
+    /* free the bytes counts arrays */
+    mfu_free(&send_counts);
+    mfu_free(&recv_counts);
+
+    /* free the receive buffer */
+    mfu_free(&recvbuf);
+
     return head;
 }
 

--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -1084,7 +1084,7 @@ static int mfu_create_link(
 
     /* read link target */
     char path[PATH_MAX + 1];
-    ssize_t readlink_rc = mfu_readlink(src_path, path, sizeof(path) - 1);
+    ssize_t readlink_rc = mfu_file_readlink(src_path, path, sizeof(path) - 1, mfu_src_file);
     if(readlink_rc < 0) {
         MFU_LOG(MFU_LOG_ERR, "Failed to read link `%s' readlink() (errno=%d %s)",
             src_path, errno, strerror(errno)
@@ -1097,7 +1097,7 @@ static int mfu_create_link(
     path[readlink_rc] = '\0';
 
     /* create new link */
-    int symlink_rc = mfu_symlink(path, dest_path);
+    int symlink_rc = mfu_file_symlink(path, dest_path, mfu_dst_file);
     if(symlink_rc < 0) {
         if(errno == EEXIST) {
             MFU_LOG(MFU_LOG_WARN,

--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -2128,6 +2128,9 @@ static int mfu_copy_files(
         }
     }
 
+    /* free the list of success/fail for each chunk */
+    mfu_free(&vals);
+
     /* free copy flags */
     mfu_free(&results);
 

--- a/src/common/mfu_flist_walk.c
+++ b/src/common/mfu_flist_walk.c
@@ -265,7 +265,8 @@ static void walk_getdents_create(CIRCLE_handle* handle)
         mfu_file_t* mfu_file = *CURRENT_PFILE;
         int status = mfu_file_lstat(path, &st, mfu_file);
         if (status != 0) {
-            /* TODO: print error */
+            MFU_LOG(MFU_LOG_ERR, "Failed to stat: '%s' (errno=%d %s)",
+                    path, errno, strerror(errno));
             return;
         }
 
@@ -317,16 +318,12 @@ static void walk_readdir_process_dir(const char* dir, CIRCLE_handle* handle)
             st.st_mode |= S_IXUSR;
             mfu_file_chmod(dir, st.st_mode, mfu_file);
             dirp = mfu_file_opendir(dir, mfu_file);
-            if (dirp == NULL) {
-                if (errno == EACCES) {
-                    MFU_LOG(MFU_LOG_ERR, "Failed to open directory with opendir: `%s' (errno=%d %s)", dir, errno, strerror(errno));
-                }
-            }
         }
     }
 
     if (! dirp) {
-        /* TODO: print error */
+        MFU_LOG(MFU_LOG_ERR, "Failed to open directory with opendir: '%s' (errno=%d %s)",
+                dir, errno, strerror(errno));
     }
     else {
         /* Read all directory entries */
@@ -381,7 +378,8 @@ static void walk_readdir_process_dir(const char* dir, CIRCLE_handle* handle)
                             }
                         }
                         else {
-                            /* error */
+                            MFU_LOG(MFU_LOG_ERR, "Failed to stat: '%s' (errno=%d %s)",
+                                    newpath, errno, strerror(errno));
                         }
                     }
 
@@ -420,7 +418,8 @@ static void walk_readdir_create(CIRCLE_handle* handle)
         mfu_file_t* mfu_file = *CURRENT_PFILE;
         int status = mfu_file_lstat(path, &st, mfu_file);
         if (status != 0) {
-            /* TODO: print error */
+            MFU_LOG(MFU_LOG_ERR, "Failed to stat: '%s' (errno=%d %s)",
+                    path, errno, strerror(errno));
             return;
         }
 
@@ -461,7 +460,8 @@ static void walk_stat_process_dir(char* dir, CIRCLE_handle* handle)
     DIR* dirp = mfu_file_opendir(dir, mfu_file);
 
     if (! dirp) {
-        /* TODO: print error */
+        MFU_LOG(MFU_LOG_ERR, "Failed to open directory with opendir: '%s' (errno=%d %s)",
+                dir, errno, strerror(errno));
     }
     else {
         while (1) {

--- a/src/common/mfu_io.h
+++ b/src/common/mfu_io.h
@@ -99,12 +99,16 @@ struct dirent* daos_readdir(DIR* dirp, mfu_file_t* mfu_file);
  ****************************/
 
 /* call readlink, retry a few times on EINTR or EIO */
+ssize_t mfu_file_readlink(const char* path, char* buf, size_t bufsize, mfu_file_t* mfu_file);
+ssize_t daos_readlink(const char* path, char* buf, size_t bufsize, mfu_file_t* mfu_file);
 ssize_t mfu_readlink(const char* path, char* buf, size_t bufsize);
 
 /* call hardlink, retry a few times on EINTR or EIO */
 int mfu_hardlink(const char* oldpath, const char* newpath);
 
 /* call symlink, retry a few times on EINTR or EIO */
+int mfu_file_symlink(const char* oldpath, const char* newpath, mfu_file_t* mfu_file);
+int daos_symlink(const char* oldpath, const char* newpath, mfu_file_t* mfu_file);
 int mfu_symlink(const char* oldpath, const char* newpath);
 
 /*****************************


### PR DESCRIPTION
**_daos: added daos_symlink and daos_readlink_**
- Added `mfu_file_readlink`
- Added `daos_readlink`
- Added `mfu_file_symlink`
- Added `daos_symlink`
- Updated corresponding DAOS entry points
- Fixed bug with `PATH_MAX` check

closes #399 


**_mfu_copy_files: fixed memory leak with vals_**
Within `mfu_copy_files`, added `mfu_free(&vals)`

closes #393 


**_mfu_file_chunk_list_alloc: fixed memory leaks_**
Witin mfu_file_chunk_list_alloc:
Added mfu_free for each of the following:
- `sendlist`
- `recvlist`
- `heads`
  - including nested linked list elements
  - does not call `mfu_file_chunk_list_free`, because that also frees the `name`, which should not be freed here, because it points to the `mfu_flist` entry which should still be valid upon exiting
- `tails`
- `counts`
-`bytes`
- `sendbufs`
  - including each index
- `recvranklist`
- `request`
- `status`
- `send_counts`
- `recv_counts`
- `recvbuf`

closes #392 


**_mfu_copy_open_file: uniformly propagate errors_**
- Changed `mfu_copy_open_file` to `return -1` on error.
- Changed callers to check for the error instead of checking if `fd<0`
  - Allows the detail of the error checks to be done in one place
  - Allows easier compatibility with DAOS

closes #398


**_mfu_flist_walk: added more error messages_**
Added a few error messages to places with TODO

closes #356 