### PR TITLE
dereference: rough draft

### DIFF
--- a/src/common/mfu_flist_walk.c
+++ b/src/common/mfu_flist_walk.c
@@ -518,10 +518,17 @@ static void walk_stat_process(CIRCLE_handle* handle)
 
     /* stat item */
     struct stat st;
-    int status = mfu_file_lstat(path, &st, mfu_file);
+    int status;
+    if (true) { /* TODO if --dereference*/
+        /* if symlink, stat the symlink value */
+        status = mfu_file_stat(path, &st, mfu_file);
+    } else {
+        /* if symlink, stat the symlink itself */
+        status = mfu_file_lstat(path, &st, mfu_file);
+    }
     if (status != 0) {
-        /* print error */
-        return;
+        MFU_LOG(MFU_LOG_ERR, "Failed to stat: '%s' (errno=%d %s)",
+                path, errno, strerror(errno));
     }
 
     /* increment our item count */

--- a/src/common/mfu_flist_walk.c
+++ b/src/common/mfu_flist_walk.c
@@ -529,6 +529,7 @@ static void walk_stat_process(CIRCLE_handle* handle)
     if (status != 0) {
         MFU_LOG(MFU_LOG_ERR, "Failed to stat: '%s' (errno=%d %s)",
                 path, errno, strerror(errno));
+        return;
     }
 
     /* increment our item count */
@@ -545,6 +546,7 @@ static void walk_stat_process(CIRCLE_handle* handle)
 
     /* recurse into directory */
     if (S_ISDIR(st.st_mode)) {
+        MFU_LOG(MFU_LOG_INFO, "walk_stat_process: S_ISDIR %s", path);
         /* before more processing check if SET_DIR_PERMS is set,
          * and set usr read and execute bits if need be */
         if (SET_DIR_PERMS) {

--- a/src/common/mfu_io.h
+++ b/src/common/mfu_io.h
@@ -71,14 +71,15 @@ int mfu_utimensat(int dirfd, const char *pathname, const struct timespec times[2
 
 /* calls lstat, and retries a few times if we get EIO or EINTR */
 int mfu_file_lstat(const char* path, struct stat* buf, mfu_file_t* mfu_file);
+int mfu_lstat(const char* path, struct stat* buf);
+int daos_lstat(const char* path, struct stat* buf, mfu_file_t* mfu_file);
 
 /* only dcp1 calls mfu_lstat64, is it necessary? */
 int mfu_lstat64(const char* path, struct stat64* buf);
 
-/* posix version of stat */
-int mfu_lstat(const char* path, struct stat* buf);
-
-/* daos version of stat */
+/* calls stat, and retries a few times if we get EIO or EINTR */
+int mfu_file_stat(const char* path, struct stat* buf, mfu_file_t* mfu_file);
+int mfu_stat(const char* path, struct stat* buf);
 int daos_stat(const char* path, struct stat* buf, mfu_file_t* mfu_file);
 
 /* call mknod, retry a few times on EINTR or EIO */


### PR DESCRIPTION
This is a work in progress for implementing --dereference
@adammoody I would like your input on the way I have approached this.
Basically, the crux of the solution is calling `stat()` instead of `lstat()` in `mfu_flist_walk.c`, and then adding corresponding:
- `mfu_file_stat`
- `mfu_stat`
- `daos_stat`

I have tested this with:
- symlinks to files
- symlinks to directories
- symlinks to symlinks
- symlinks to directories with other symlinks to ...

And so far I don't see any issues with it. The end result is that _**structure**_ of the destination is exactly the same as the _**structure**_ of the source, but the _**symlinks**_ from the source are just replaced with the underlying files/directories. I have also compared this to `cp -r --dereference` and this is how it is done.

My concern is really that this just seems too simple, so I would like any input you might have.

As a side note, this does not work for DAOS, but only because our `dfs` library does not have support for opening symlinks. I'm not sure when that support will be added (in progress), but once this is tried-and-true, I don't mind pushing without full DAOS support for now, since other users could benefit from this.