### PR TITLE
daos: gracefully handle failed fiemap

### DIFF
--- a/src/common/mfu_io.h
+++ b/src/common/mfu_io.h
@@ -152,7 +152,9 @@ ssize_t daos_pwrite(const char* file, const void* buf, size_t size, off_t offset
 ssize_t mfu_pwrite(const char* file, int fd, const void* buf, size_t size, off_t offset);
 
 /* truncate a file */
+int mfu_file_truncate(const char* file, off_t length, mfu_file_t* mfu_file);
 int mfu_truncate(const char* file, off_t length);
+int daos_truncate(const char* file, off_t length, mfu_file_t* mfu_file);
 
 /* ftruncate a file */
 int mfu_file_ftruncate(mfu_file_t* mfu_file, off_t length);


### PR DESCRIPTION
**mfu_io**
- Added `mfu_file_truncate`
- Added `daos_truncate`

**mfu_flist_copy.c**
- `mfu_copy_file_fiemap`
  - Skip for DAOS src
    - Not yet supported
  - Skip if `ioctl` fails with `ENOTSUP`
    - DAOS DFUSE-mounted path does not support this
    - _**it seems that `cp` also silently ignores this**_
  - Change `goto fail` to `goto fail_fiemap` for clarity
  - Fixed some memory leaks for error conditions
    - `goto fail_fiemap` instead of `goto fail_normal_copy`
- Changed an occurrence of `mfu_truncate` to `mfu_file_truncate`

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>