### PR TITLE
fix enable DAOS link in DAOS-Support README

### DIFF
--- a/DAOS-Support.md
+++ b/DAOS-Support.md
@@ -2,7 +2,7 @@
 
 [DAOS](https://github.com/daos-stack/daos) is supported as a backend storage system in dcp. The build instructions for
 enabling DAOS support can be found here:
-[Enable DAOS](https://mpifileutils.readthedocs.io/en/latest/build.html).
+[Enable DAOS](https://mpifileutils.readthedocs.io/en/latest/build.html#build-everything-directly).
 The following are ways that DAOS can be used to move data both across DAOS as well as POSIX
 filesystems:
 

--- a/DAOS-Support.md
+++ b/DAOS-Support.md
@@ -2,8 +2,7 @@
 
 [DAOS](https://github.com/daos-stack/daos) is supported as a backend storage system in dcp. The build instructions for
 enabling DAOS support can be found here:
-[Enable DAOS](https://github.com/hpc/mpifileutils/doc/rst/build.rst).
-
+[Enable DAOS](https://mpifileutils.readthedocs.io/en/latest/build.html).
 The following are ways that DAOS can be used to move data both across DAOS as well as POSIX
 filesystems:
 


### PR DESCRIPTION
Update the Enable DAOS link in the DAOS-Support README.

Signed-off-by: Danielle Sikich <danielle.sikich@intel.com>