### PR TITLE
Separate xattrs from general preserve attributes (only intended as an example)

### DIFF
--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -340,7 +340,7 @@ static int mfu_copy_xattrs(
                 int setrc = lsetxattr(dest_path, name, val, (size_t) val_size, 0);
                 if(setrc != 0) {
                     /* failed to set attribute */
-                    MFU_LOG(MFU_LOG_ERR, "Failed to set value for name=%s on `%s' llistxattr() (errno=%d %s)",
+                    MFU_LOG(MFU_LOG_ERR, "Failed to set value for name=%s on `%s' lsetxattr() (errno=%d %s)",
                         name, dest_path, errno, strerror(errno)
                        );
                     rc = -1;

--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -934,7 +934,7 @@ static int mfu_create_directory(
      * creating / striping files in the directory */
 
     /* copy extended attributes on directory */
-    if (copy_opts->preserve) {
+    if (copy_opts->preserve && copy_opts->preserve_xattrs) {
         int tmp_rc = mfu_copy_xattrs(list, idx, dest_path);
         if (tmp_rc < 0) {
             rc = -1;
@@ -1125,7 +1125,7 @@ static int mfu_create_link(
     }
 
     /* set permissions on link */
-    if (copy_opts->preserve) {
+    if (copy_opts->preserve && copy_opts->preserve_xattrs) {
         int xattr_rc = mfu_copy_xattrs(list, idx, dest_path);
         if (xattr_rc < 0) {
             rc = -1;
@@ -1198,7 +1198,7 @@ static int mfu_create_file(
     /* copy extended attributes, important to do this first before
      * writing data because some attributes tell file system how to
      * stripe data, e.g., Lustre */
-    if (copy_opts->preserve) {
+    if (copy_opts->preserve && copy_opts->preserve_xattrs) {
         int tmp_rc = mfu_copy_xattrs(list, idx, dest_path);
         if (tmp_rc < 0) {
             rc = -1;
@@ -3220,6 +3220,7 @@ mfu_copy_opts_t* mfu_copy_opts_new(void)
 
     /* By default, don't bother to preserve all attributes. */
     opts->preserve = false;
+    opts->preserve_xattrs = false;
 
     /* By default, don't use O_DIRECT. */
     opts->direct = false;

--- a/src/common/mfu_param_path.h
+++ b/src/common/mfu_param_path.h
@@ -109,6 +109,7 @@ typedef struct {
     char*  dest_path;     /* prefex of destination directory */
     char*  input_file;    /* file name of input list */
     bool   preserve;      /* whether to preserve timestamps, ownership, permissions, etc. */
+    bool   preserve_xattrs;      /* whether to preserve xattrs. */
     bool   direct;        /* whether to use O_DIRECT */
     bool   sparse;        /* whether to create sparse files */
     size_t chunk_size;    /* size to chunk files by */

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -633,6 +633,7 @@ void print_usage(void)
     printf("  -s, --direct             - open files with O_DIRECT\n");
     printf("  -S, --sparse             - create sparse files when possible\n");
     printf("      --progress <N>       - print progress every N seconds\n");
+    printf("  -X, --xattrs             - preserve extended attributes\n");
     printf("  -v, --verbose            - verbose output\n");
     printf("  -q, --quiet              - quiet output\n");
     printf("  -h, --help               - print usage\n");
@@ -698,6 +699,7 @@ int main(int argc, char** argv)
         {"direct"               , no_argument      , 0, 's'},
         {"sparse"               , no_argument      , 0, 'S'},
         {"progress"             , required_argument, 0, 'P'},
+        {"xattrs"               , no_argument      , 0, 'X'},
         {"verbose"              , no_argument      , 0, 'v'},
         {"quiet"                , no_argument      , 0, 'q'},
         {"help"                 , no_argument      , 0, 'h'},
@@ -867,6 +869,12 @@ int main(int argc, char** argv)
                 break;
             case 'P':
                 mfu_progress_timeout = atoi(optarg);
+                break;
+            case 'X':
+                mfu_copy_opts->preserve_xattrs = true;
+                if(rank == 0) {
+                    MFU_LOG(MFU_LOG_INFO, "Preserving extended attributes.");
+                }
                 break;
             case 'v':
                 mfu_debug_level = MFU_LOG_VERBOSE;

--- a/src/dsync/dsync.c
+++ b/src/dsync/dsync.c
@@ -2842,7 +2842,6 @@ int main(int argc, char **argv)
 
     /* By default, sync option will preserve most attributes. */
     copy_opts->preserve = true;
-    copy_opts->preserve_xattrs = true;
 
     /* flag to check for sync option */
     copy_opts->do_sync = 1;

--- a/src/dsync/dsync.c
+++ b/src/dsync/dsync.c
@@ -2840,8 +2840,9 @@ int main(int argc, char **argv)
     /* verbose by default */
     mfu_debug_level = MFU_LOG_VERBOSE;
 
-    /* By default, sync option will preserve all attributes. */
+    /* By default, sync option will preserve most attributes. */
     copy_opts->preserve = true;
+    copy_opts->preserve_xattrs = true;
 
     /* flag to check for sync option */
     copy_opts->do_sync = 1;
@@ -2860,6 +2861,7 @@ int main(int argc, char **argv)
         {"link-dest",     1, 0, 'l'},
         {"sparse",        0, 0, 'S'},
         {"progress",      1, 0, 'P'},
+        {"xattrs",        0, 0, 'X'},
         {"verbose",       0, 0, 'v'},
         {"quiet",         0, 0, 'q'},
         {"help",          0, 0, 'h'},
@@ -2944,6 +2946,12 @@ int main(int argc, char **argv)
             break;
         case 'P':
             mfu_progress_timeout = atoi(optarg);
+            break;
+        case 'X':
+            copy_opts->preserve_xattrs = true;
+            if(rank == 0) {
+                MFU_LOG(MFU_LOG_INFO, "Preserving extended attributes.");
+            }
             break;
         case 'v':
             options.verbose++;


### PR DESCRIPTION
This is a quick mockup for separating xattrs from normal preserve, in rsync preserving xattrs is off by default and only enabled if explicitly requested. dsync should behave the same (and should preferably behave as rsync regarding ACLs too)

I know the short 'X' option clashes with dcp option daos-prefix, but I left it as 'X' since that is what rsync uses for this.
