### PR TITLE
Fix compile error with GPFS_SUPPORT

### DIFF
--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -516,7 +516,7 @@ static int mfu_copy_acls(
 
          /* free the memory from the buffer */
          mfu_free(&aclbufmem);
-
+    }
 #endif /* GPFS_SUPPORT */
 
     return rc;


### PR DESCRIPTION
There is a syntax error when GPFS_SUPPORT is enabled
``` c
if(type != MFU_TYPE_LINK) {
```
was not closed correctly before endif