### PR TITLE
update libmfu.so to version 1.0.0

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Version for the shared mfu library
-set(MFU_VERSION_MAJOR 0) # Incompatible API changes
+set(MFU_VERSION_MAJOR 1) # Incompatible API changes
 set(MFU_VERSION_MINOR 0) # Backwards-compatible functionality
 set(MFU_VERSION_PATCH 0) # Backwards-compatible fixes
 set(MFU_VERSION ${MFU_VERSION_MAJOR}.${MFU_VERSION_MINOR}.${MFU_VERSION_PATCH})


### PR DESCRIPTION
The major version of libmfu.so needs to be updated
since there are new parameters to these functions:
- `mfu_flist.h` -> `mfu_flist_stat`
- `mfu_param_path.h` -> `mfu_param_path_check_copy`

The new parameters are not backwards-compatible;
hence, the major version is updated.

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>