### PR TITLE
daos: remove svcl

### DIFF
--- a/DAOS-Support.md
+++ b/DAOS-Support.md
@@ -35,7 +35,7 @@ the pool and container UUID from the path. This feature can only be used if the
 container is created with a path.
 
 ```shell
-$ mpirun -np 3 --daos-dst-svcl 0 -v /tmp/$USER/s /tmp/$USER/conts/p1cont1
+$ mpirun -np 3 -v /tmp/$USER/s /tmp/$USER/conts/p1cont1
 [2020-04-23T17:04:15]   Items: 6
 [2020-04-23T17:04:15]   Directories: 3
 [2020-04-23T17:04:15]   Files: 3
@@ -50,7 +50,7 @@ with a path. The destination is the relative path within the DAOS container, whi
 in this example is the root of the container. 
 
 ```shell
-$ mpirun -np 3 dcp --daos-dst-svcl 0 -v --daos-dst-pool $pool --daos-dst-cont $p1cont1 /tmp/$USER/s /
+$ mpirun -np 3 dcp -v --daos-dst-pool $pool --daos-dst-cont $p1cont1 /tmp/$USER/s /
 [2020-04-23T17:17:51] Items: 6
 [2020-04-23T17:17:51]   Directories: 3
 [2020-04-23T17:17:51]   Files: 3
@@ -62,7 +62,7 @@ Show a copy from one DAOS container to another container that exists in the same
 pool. A DAOS Unified Namespace path is used as the source and the destination.
 
 ```shell
-$ mpirun -np 3 dcp --daos-src-svcl 0 --daos-dst-svcl 0 -v /tmp/$USER/conts/p1cont1 /tmp/$USER/conts/p1cont2
+$ mpirun -np 3 dcp -v /tmp/$USER/conts/p1cont1 /tmp/$USER/conts/p1cont2
 [2020-04-23T17:04:15] Items: 6
 [2020-04-23T17:04:15]   Directories: 3
 [2020-04-23T17:04:15]   Files: 3
@@ -76,7 +76,7 @@ is the relative path within the DAOS container, which in this case is a subset o
 the DAOS container. 
 
 ```shell
-$ mpirun -np 3 dcp --daos-src-svcl 0 --daos-dst-svcl 0 -v --daos-src-pool $pool --daos-src-cont $p1cont1 \
+$ mpirun -np 3 dcp -v --daos-src-pool $pool --daos-src-cont $p1cont1 \
 --daos-dst-pool $pool2 --daos-dst-cont $p2cont2 /s/biggerfile /
 [2020-04-28T00:47:59] Items: 1
 [2020-04-28T00:47:59]   Directories: 0
@@ -90,7 +90,7 @@ This example copies data from a DAOS container to /tmp, where a DAOS
 Unified Namespace path is used as the source. 
 
 ```shell
-$ mpirun -np 3 dcp --daos-src-svcl 0 -v /tmp/$USER/conts/p1cont1 /tmp/$USER/d
+$ mpirun -np 3 dcp -v /tmp/$USER/conts/p1cont1 /tmp/$USER/d
 [2020-04-23T17:17:51] Items: 6
 [2020-04-23T17:17:51]   Directories: 3
 [2020-04-23T17:17:51]   Files: 3

--- a/doc/rst/dcp.1.rst
+++ b/doc/rst/dcp.1.rst
@@ -48,14 +48,6 @@ OPTIONS
 
    Specify the DAOS destination container to be used.
 
-.. option:: --daos-src-svcl SVC
-
-   Specify the DAOS source replication level to be used.
-
-.. option:: --daos-dst-svcl SVC
-
-   Specify the DAOS destination replication level to be used.
-
 .. option:: --daos-prefix PREFIX
 
    Specify the DAOS prefix to be used. This is only necessary

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Version for the shared mfu library
-set(MFU_VERSION_MAJOR 0) # Incompatible API changes
+set(MFU_VERSION_MAJOR 1) # Incompatible API changes
 set(MFU_VERSION_MINOR 0) # Backwards-compatible functionality
 set(MFU_VERSION_PATCH 0) # Backwards-compatible fixes
 set(MFU_VERSION ${MFU_VERSION_MAJOR}.${MFU_VERSION_MINOR}.${MFU_VERSION_PATCH})

--- a/src/common/mfu_util.c
+++ b/src/common/mfu_util.c
@@ -115,7 +115,6 @@ void daos_bcast_handle(
 
 int daos_connect(
   int rank,
-  const char* svc,
   uuid_t pool_uuid,
   uuid_t cont_uuid,
   daos_handle_t* poh,
@@ -130,23 +129,15 @@ int daos_connect(
     /* have rank 0 connect to the pool and container,
      * we'll then broadcast the handle ids from rank 0 to everyone else */
     if (rank == 0) {
-        /* Parse svc and connect to DAOS pool */
+        /* Connect to DAOS pool */
         if (connect_pool) {
-            d_rank_list_t* svcl = daos_rank_list_parse(svc, ":");
-            if (svcl == NULL) {
-                MFU_LOG(MFU_LOG_ERR, "Failed to parse DAOS rank list: '%s'", svc);
-                goto bcast;
-            }
-
             daos_pool_info_t pool_info = {0};
-            rc = daos_pool_connect(pool_uuid, NULL, svcl, DAOS_PC_RW,
+            rc = daos_pool_connect(pool_uuid, NULL, NULL, DAOS_PC_RW,
                     poh, &pool_info, NULL);
             if (rc != 0) {
                 MFU_LOG(MFU_LOG_ERR, "Failed to connect to pool");
-                d_rank_list_free(svcl);
                 goto bcast;
             }
-            d_rank_list_free(svcl);
         }
 
         /* Try to open the container 

--- a/src/common/mfu_util.h
+++ b/src/common/mfu_util.h
@@ -128,7 +128,6 @@ void daos_bcast_handle(
 /* connect to DAOS pool, and then open container */
 int daos_connect(
   int rank,
-  const char* svc,
   uuid_t pool_uuid,
   uuid_t cont_uuid,
   daos_handle_t* poh,


### PR DESCRIPTION
The svcl is no longer required when connecting to
a DAOS pool, so it has been removed:
- Removed from DAOS-Support.md
- Removed from doc/rst/dcp.1.rst
- Removed from dcp.c
- Removed from mfu_util

Updated the shared libmfu.so major version,
based on previous changes and these changes.

closes #426 

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>