### PR TITLE
daos: add support for copying daos containers at obj level

### DIFF
--- a/src/common/mfu_daos.h
+++ b/src/common/mfu_daos.h
@@ -1,6 +1,12 @@
 #include "mfu.h"
 
 #include <daos.h>
+#include "mfu_flist_internal.h"
+
+#define ENUM_KEY_BUF		32 /* size of each dkey/akey */
+#define ENUM_LARGE_KEY_BUF	(512 * 1024) /* 512k large key */
+#define ENUM_DESC_NR		5 /* number of keys/records returned by enum */
+#define ENUM_DESC_BUF		512 /* all keys/records returned by enum */
 
 enum handleType {
     POOL_HANDLE,
@@ -38,7 +44,8 @@ int daos_setup(
   char** argpaths,
   daos_args_t* da,
   mfu_file_t* mfu_src_file,
-  mfu_file_t* mfu_dst_file
+  mfu_file_t* mfu_dst_file,
+  bool* is_posix_copy
 );
 
 /* Unmount DFS.
@@ -48,5 +55,20 @@ int daos_setup(
 int daos_cleanup(
   daos_args_t* da,
   mfu_file_t* mfu_src_file,
-  mfu_file_t* mfu_dst_file
+  mfu_file_t* mfu_dst_file,
+  bool* is_posix_copy
+);
+
+/* walk objects in daos and insert to given flist */
+int mfu_flist_walk_daos(
+    daos_args_t* da,
+    daos_epoch_t* epoch,
+    mfu_flist flist
+);
+
+/* copy objects in flist to destination listed in daos args,
+ * copies DAOS data at object level (non-posix) */
+int mfu_flist_copy_daos(
+    daos_args_t* da,
+    mfu_flist flist
 );

--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -394,6 +394,9 @@ const char* mfu_flist_file_get_username(mfu_flist flist, uint64_t index);
 const char* mfu_flist_file_get_groupname(mfu_flist flist, uint64_t index);
 
 /* set properties on specified item in local flist */
+#ifdef DAOS_SUPPORT
+void mfu_flist_file_set_oid(mfu_flist flist, uint64_t index, daos_obj_id_t oid);
+#endif
 void mfu_flist_file_set_name(mfu_flist flist, uint64_t index, const char* name);
 void mfu_flist_file_set_type(mfu_flist flist, uint64_t index, mfu_filetype type);
 void mfu_flist_file_set_detail(mfu_flist flist, uint64_t index, int detail);

--- a/src/common/mfu_flist_internal.h
+++ b/src/common/mfu_flist_internal.h
@@ -41,6 +41,9 @@ typedef struct list_elem {
     uint64_t ctime_nsec;    /* create time nanoseconds */
     uint64_t size;          /* file size in bytes */
     struct list_elem* next; /* pointer to next item */
+    /* vars for a non-posix DAOS copy */
+    uint64_t obj_id_lo;
+    uint64_t obj_id_hi;
 } elem_t;
 
 /* holds an array of objects: users, groups, or file data */
@@ -56,7 +59,7 @@ typedef struct {
 typedef struct flist {
     int detail;              /* set to 1 if we have stat, 0 if just file name */
     uint64_t offset;         /* global offset of our file across all procs */
-    uint64_t total_files;    /* total file count in list across all procs */
+    uint64_t total_files;    /* total item count in list across all procs */
     uint64_t total_users;    /* number of users (valid if detail is 1) */
     uint64_t total_groups;   /* number of groups (valid if detail is 1) */
     uint64_t max_file_name;  /* maximum filename strlen()+1 in global list */


### PR DESCRIPTION
This adds support for copying any type of daos container
in parallel.

    * add obj_id_lo and obj_id_hi to elem_t struct
    * add total_oids field to flist
    * add a pack and unpack call for obj_id_lo and obj_id_hi
    * create mfu_flist_global_oid_size to return total oids
    * add boolean is_posix_copy for non-posix copies
    * adds daos_obj_copy function and helper functions

This copy starts by retrieving all obj ids on rank 0,
then it uses the mfu_flist_spread function to distribute
all obj ids evenly across ranks. After the obj ids are
distributed, the obj ids are copied using the local
flist.

Also, daos will split the anchor used to retrive all
obj ids and enumerate the dkeys, akeys, and records.
There is work that still needs to be done from the daos
level to split the anchor for the object iterator table
used to retrieve obj ids. In the case that a large
record extent needs to be copied, daos already chunks
the record extents using their index ranges. Each record
is of a fixed size, where multiple records is a record
extent.

Signed-off-by: Danielle Sikich <danielle.sikich@intel.com>