### PR TITLE
daos: improvements

### DIFF
--- a/doc/rst/dcp.1.rst
+++ b/doc/rst/dcp.1.rst
@@ -32,27 +32,18 @@ OPTIONS
    "GB" can immediately follow the number without spaces (eg. 64MB).
    The default chunksize is 1MB.
 
-.. option:: --daos-src-pool POOL
-
-   Specify the DAOS source pool to be used.
-
-.. option:: --daos-dst-pool POOL
-
-   Specify the DAOS destination pool to be used.
-
-.. option:: --daos-src-cont CONTAINER
-
-   Specify the DAOS source container to be used.
-
-.. option:: --daos-dst-cont CONTAINER
-
-   Specify the DAOS destination container to be used.
-
 .. option:: --daos-prefix PREFIX
 
    Specify the DAOS prefix to be used. This is only necessary
    if copying a subset of a POSIX container in DAOS using a
    Unified Namespace path.
+
+.. option:: --daos-api API
+
+   Specify the DAOS API to be used. By default, the API is automatically
+   determined based on the container type, where POSIX containers use the
+   DFS API, and all other containers use the DAOS object API.
+   Values must be in {DFS, DAOS}.
 
 .. option:: -i, --input FILE
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Version for the shared mfu library
-set(MFU_VERSION_MAJOR 1) # Incompatible API changes
+set(MFU_VERSION_MAJOR 2) # Incompatible API changes
 set(MFU_VERSION_MINOR 0) # Backwards-compatible functionality
 set(MFU_VERSION_PATCH 0) # Backwards-compatible fixes
 set(MFU_VERSION ${MFU_VERSION_MAJOR}.${MFU_VERSION_MINOR}.${MFU_VERSION_PATCH})

--- a/src/common/mfu_daos.h
+++ b/src/common/mfu_daos.h
@@ -34,6 +34,7 @@ typedef struct {
     char* src_path;        /* allocated src path */
     char* dst_path;        /* allocated dst path */
     daos_api_t api;        /* API to use */
+    daos_epoch_t epc;      /* src container epoch */
 } daos_args_t;
 
 /* Return a newly allocated daos_args_t structure.
@@ -47,6 +48,11 @@ void daos_args_delete(daos_args_t** pda);
 int daos_parse_api_str(
     const char* api_str,
     daos_api_t* api);
+
+/* Parse a string representation of the epoch */
+int daos_parse_epc_str(
+    const char* epc_str,
+    daos_epoch_t* epc);
 
 /* Setup DAOS arguments.
  * Connect to pools.
@@ -74,7 +80,6 @@ int daos_cleanup(
 /* walk objects in daos and insert to given flist */
 int mfu_flist_walk_daos(
     daos_args_t* da,
-    daos_epoch_t* epoch,
     mfu_flist flist
 );
 

--- a/src/common/mfu_daos.h
+++ b/src/common/mfu_daos.h
@@ -14,6 +14,12 @@ enum handleType {
     ARRAY_HANDLE
 };
 
+typedef enum {
+    DAOS_API_AUTO,
+    DAOS_API_DFS,
+    DAOS_API_DAOS
+} daos_api_t;
+
 /* struct for holding DAOS arguments */
 typedef struct {
     daos_handle_t src_poh; /* source pool handle */
@@ -25,6 +31,9 @@ typedef struct {
     uuid_t src_cont_uuid;  /* source container UUID */
     uuid_t dst_cont_uuid;  /* destination container UUID */
     char* dfs_prefix;      /* prefix for UNS */
+    char* src_path;        /* allocated src path */
+    char* dst_path;        /* allocated dst path */
+    daos_api_t api;        /* API to use */
 } daos_args_t;
 
 /* Return a newly allocated daos_args_t structure.
@@ -33,6 +42,11 @@ daos_args_t* daos_args_new(void);
 
 /* free a daos_args_t structure */
 void daos_args_delete(daos_args_t** pda);
+
+/* Parse a string representation of the API */
+int daos_parse_api_str(
+    const char* api_str,
+    daos_api_t* api);
 
 /* Setup DAOS arguments.
  * Connect to pools.
@@ -44,8 +58,7 @@ int daos_setup(
   char** argpaths,
   daos_args_t* da,
   mfu_file_t* mfu_src_file,
-  mfu_file_t* mfu_dst_file,
-  bool* is_posix_copy
+  mfu_file_t* mfu_dst_file
 );
 
 /* Unmount DFS.
@@ -55,8 +68,7 @@ int daos_setup(
 int daos_cleanup(
   daos_args_t* da,
   mfu_file_t* mfu_src_file,
-  mfu_file_t* mfu_dst_file,
-  bool* is_posix_copy
+  mfu_file_t* mfu_dst_file
 );
 
 /* walk objects in daos and insert to given flist */

--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -1246,8 +1246,8 @@ static int mfu_create_file(
             status = 0;
         } else {
             /* had an error stating destination file */
-            MFU_LOG(MFU_LOG_ERR, "mfu_lstat() file: `%s' (errno=%d %s)",
-                      dest_path, errno, strerror(errno));
+            MFU_LOG(MFU_LOG_ERR, "mfu_file_lstat() file: `%s' (errno=%d %s)",
+                    dest_path, errno, strerror(errno));
         }
     }
 

--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -175,7 +175,7 @@ static int mfu_copy_open_file(
     }
 
 #ifdef DAOS_SUPPORT
-    if (mfu_file->type == DAOS) {
+    if (mfu_file->type == DFS) {
         if (mfu_file->obj == NULL) {
             return -1;
         }
@@ -1819,7 +1819,7 @@ static int mfu_copy_file_fiemap(
 
 #ifdef DAOS_SUPPORT
     /* Not yet supported */
-    if (mfu_src_file->type == DAOS) {
+    if (mfu_src_file->type == DFS) {
         goto fail_normal_copy;
     }
 #endif
@@ -2359,7 +2359,7 @@ int mfu_flist_copy(
     int rc = 0;
 
     /* DAOS only supports using one source path */
-    if (mfu_src_file->type == DAOS || mfu_dst_file->type == DAOS) {
+    if (mfu_src_file->type == DFS || mfu_dst_file->type == DFS) {
         if (numpaths != 1) {
             MFU_LOG(MFU_LOG_ERR, "Only one source can be specified when using DAOS");
         }

--- a/src/common/mfu_flist_walk.c
+++ b/src/common/mfu_flist_walk.c
@@ -797,14 +797,19 @@ void mfu_flist_stat(
         if (do_dereference) {
             /* dereference symbolic link */
             status = mfu_file_stat(name, &st, mfu_file);
+            if (status != 0) {
+                MFU_LOG(MFU_LOG_ERR, "mfu_file_stat() failed: '%s' rc=%d (errno=%d %s)",
+                        name, status, errno, strerror(errno));
+                continue;
+            }
         } else {
             /* don't dereference symbolic links */
             status = mfu_file_lstat(name, &st, mfu_file);
-        }
-        if (status != 0) {
-            MFU_LOG(MFU_LOG_ERR, "mfu_lstat() failed: '%s' rc=%d (errno=%d %s)",
-                    name, status, errno, strerror(errno));
-            continue;
+            if (status != 0) {
+                MFU_LOG(MFU_LOG_ERR, "mfu_file_lstat() failed: '%s' rc=%d (errno=%d %s)",
+                        name, status, errno, strerror(errno));
+                continue;
+            }
         }
 
         /* insert item into output list */

--- a/src/common/mfu_flist_walk.c
+++ b/src/common/mfu_flist_walk.c
@@ -713,12 +713,15 @@ void mfu_flist_walk_param_paths(uint64_t num,
     /* allocate memory to hold a list of paths */
     const char** path_list = (const char**) MFU_MALLOC(num * sizeof(char*));
 
+#ifdef DAOS_SUPPORT
     /* DAOS only supports using one source path */
-    if (mfu_file->type == DAOS) {
+    if (mfu_file->type == DFS) {
         if (num != 1) {
             MFU_LOG(MFU_LOG_ERR, "Only one source can be specified when using DAOS");
+            return;
         }
     }
+#endif
 
     /* fill list of paths and print each one */
     uint64_t i;

--- a/src/common/mfu_io.c
+++ b/src/common/mfu_io.c
@@ -928,6 +928,37 @@ retry:
     return rc;
 }
 
+/* calls realpath */
+char* mfu_file_realpath(const char* path, char* resolved_path, mfu_file_t* mfu_file)
+{
+    if (mfu_file->type == POSIX) {
+        char* p = mfu_realpath(path, resolved_path);
+        return p;
+    } else if (mfu_file->type == DAOS) {
+        char* p = daos_realpath(path, resolved_path, mfu_file);
+        return p;
+    } else {
+        MFU_ABORT(-1, "File type not known: %s type=%d",
+                  path, mfu_file->type);
+    }
+}
+
+char* mfu_realpath(const char* path, char* resolved_path)
+{
+    char* p = realpath(path, resolved_path);
+    return p;
+}
+
+char* daos_realpath(const char* path, char* resolved_path, mfu_file_t* mfu_file)
+{
+#ifdef DAOS_SUPPORT
+    /* There is currently not a reasonable way to do this */
+    return NULL;
+#else
+    return NULL;
+#endif
+}
+
 /*****************************
  * Links
  ****************************/

--- a/src/common/mfu_io.c
+++ b/src/common/mfu_io.c
@@ -262,7 +262,7 @@ int mfu_file_access(const char* path, int amode, mfu_file_t* mfu_file)
     if (mfu_file->type == POSIX) {
         int rc = mfu_access(path, amode);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         int rc = daos_access(path, amode, mfu_file);
         return rc;
     } else {
@@ -330,7 +330,7 @@ int mfu_file_faccessat(int dirfd, const char* path, int amode, int flags, mfu_fi
     if (mfu_file->type == POSIX) {
         int rc = mfu_faccessat(dirfd, path, amode, flags);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         int rc = daos_faccessat(dirfd, path, amode, flags, mfu_file);
         return rc;
     } else {
@@ -437,7 +437,7 @@ int mfu_file_lchown(const char* path, uid_t owner, gid_t group, mfu_file_t* mfu_
     if (mfu_file->type == POSIX) {
         int rc = mfu_lchown(path, owner, group);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         int rc = daos_lchown(path, owner, group, mfu_file);
         return rc;
     } else {
@@ -535,7 +535,7 @@ int mfu_file_chmod(const char* path, mode_t mode, mfu_file_t* mfu_file)
     if (mfu_file->type == POSIX) {
         int rc = mfu_chmod(path, mode);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         int rc = daos_chmod(path, mode, mfu_file);
         return rc;
     } else {
@@ -551,7 +551,7 @@ int mfu_file_utimensat(int dirfd, const char* pathname, const struct timespec ti
     if (mfu_file->type == POSIX) {
         int rc = mfu_utimensat(dirfd, pathname, times, flags);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         int rc = daos_utimensat(dirfd, pathname, times, flags, mfu_file);
         return rc;
     } else {
@@ -712,7 +712,7 @@ int mfu_file_stat(const char* path, struct stat* buf, mfu_file_t* mfu_file)
     if (mfu_file->type == POSIX) {
         int rc = mfu_stat(path, buf);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         int rc = daos_stat(path, buf, mfu_file);
         return rc;
     } else {
@@ -782,7 +782,7 @@ int mfu_file_lstat(const char* path, struct stat* buf, mfu_file_t* mfu_file)
     if (mfu_file->type == POSIX) {
         int rc = mfu_lstat(path, buf);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         int rc = daos_lstat(path, buf, mfu_file);
         return rc;
     } else {
@@ -898,7 +898,7 @@ int mfu_file_mknod(const char* path, mode_t mode, dev_t dev, mfu_file_t* mfu_fil
     if (mfu_file->type == POSIX) {
         int rc = mfu_mknod(path, mode, dev);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         int rc = daos_mknod(path, mode, dev, mfu_file);
         return rc;
     } else {
@@ -934,7 +934,7 @@ char* mfu_file_realpath(const char* path, char* resolved_path, mfu_file_t* mfu_f
     if (mfu_file->type == POSIX) {
         char* p = mfu_realpath(path, resolved_path);
         return p;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         char* p = daos_realpath(path, resolved_path, mfu_file);
         return p;
     } else {
@@ -1047,7 +1047,7 @@ ssize_t mfu_file_readlink(const char* path, char* buf, size_t bufsize, mfu_file_
 
     if (mfu_file->type == POSIX) {
         rc = mfu_readlink(path, buf, bufsize);
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         rc = daos_readlink(path, buf, bufsize, mfu_file);
     } else {
         MFU_ABORT(-1, "File type not known: %s type=%d",
@@ -1133,7 +1133,7 @@ int mfu_file_symlink(const char* oldpath, const char* newpath, mfu_file_t* mfu_f
 
     if (mfu_file->type == POSIX) {
         rc = mfu_symlink(oldpath, newpath);
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         rc = daos_symlink(oldpath, newpath, mfu_file);
     } else {
         MFU_ABORT(-1, "File type not known: %s type=%d",
@@ -1307,7 +1307,7 @@ void mfu_file_open(const char* file, int flags, mfu_file_t* mfu_file, ...)
         } else {
             mfu_file->fd = mfu_open(file, flags);
         }
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         daos_open(file, flags, mode, mfu_file);
     } else {
         MFU_ABORT(-1, "File type not known: %s type=%d",
@@ -1360,7 +1360,7 @@ int mfu_file_close(const char* file, mfu_file_t* mfu_file)
             mfu_file->fd = -1;
         }
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         int rc = daos_close(file, mfu_file);
 #ifdef DAOS_SUPPORT
         if (rc == 0) {
@@ -1413,7 +1413,7 @@ off_t mfu_file_lseek(const char* file, mfu_file_t* mfu_file, off_t pos, int when
     if (mfu_file->type == POSIX) {
         off_t rc = mfu_lseek(file, mfu_file->fd, pos, whence);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         off_t rc = daos_lseek(file, mfu_file, pos, whence);
         return rc;
     } else {
@@ -1428,7 +1428,7 @@ ssize_t mfu_file_read(const char* file, void* buf, size_t size, mfu_file_t* mfu_
     if (mfu_file->type == POSIX) {
         ssize_t got_size = mfu_read(file, mfu_file->fd, buf, size);
         return got_size;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         ssize_t got_size = daos_read(file, buf, size, mfu_file);
         return got_size;
     } else {
@@ -1511,7 +1511,7 @@ ssize_t mfu_file_write(const char* file, const void* buf, size_t size, mfu_file_
     if (mfu_file->type == POSIX) {
         ssize_t num_bytes_written = mfu_write(file, mfu_file->fd, buf, size);
         return num_bytes_written;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         ssize_t num_bytes_written = daos_write(file, buf, size, mfu_file);
         return num_bytes_written;
     } else {
@@ -1593,7 +1593,7 @@ ssize_t mfu_file_pread(const char* file, void* buf, size_t size, off_t offset, m
     if (mfu_file->type == POSIX) {
         ssize_t rc = mfu_pread(file, mfu_file->fd, buf, size, offset);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         ssize_t rc = daos_pread(file, buf, size, offset, mfu_file);
         return rc;
     } else {
@@ -1664,7 +1664,7 @@ ssize_t mfu_file_pwrite(const char* file, const void* buf, size_t size, off_t of
     if (mfu_file->type == POSIX) {
         ssize_t rc = mfu_pwrite(file, mfu_file->fd, buf, size, offset);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         ssize_t rc = daos_pwrite(file, buf, size, offset, mfu_file);
         return rc;
     } else {
@@ -1736,7 +1736,7 @@ int mfu_file_truncate(const char* file, off_t length, mfu_file_t* mfu_file)
     if (mfu_file->type == POSIX) {
         int rc = mfu_truncate(file, length);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         int rc = daos_truncate(file, length, mfu_file);
         return rc;
     } else {
@@ -1866,7 +1866,7 @@ int mfu_file_ftruncate(mfu_file_t* mfu_file, off_t length)
     if (mfu_file->type == POSIX) {
         int rc = mfu_ftruncate(mfu_file->fd, length);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         int rc = daos_ftruncate(mfu_file, length);
         return rc;
     } else {
@@ -1881,7 +1881,7 @@ int mfu_file_unlink(const char* file, mfu_file_t* mfu_file)
     if (mfu_file->type == POSIX) {
         int rc = mfu_unlink(file);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         int rc = daos_unlink(file, mfu_file);
         return rc;
     } else {
@@ -2050,7 +2050,7 @@ int mfu_file_mkdir(const char* dir, mode_t mode, mfu_file_t* mfu_file)
     if (mfu_file->type == POSIX) {
         int rc = mfu_mkdir(dir, mode);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         int rc = daos_mkdir(dir, mode, mfu_file);
         return rc;
     } else {
@@ -2184,7 +2184,7 @@ DIR* mfu_file_opendir(const char* dir, mfu_file_t* mfu_file)
     if (mfu_file->type == POSIX) {
         DIR* dirp = mfu_opendir(dir);
         return dirp;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         DIR* dirp = daos_opendir(dir, mfu_file);
         return dirp;
     } else {
@@ -2238,7 +2238,7 @@ int mfu_file_closedir(DIR* dirp, mfu_file_t* mfu_file)
     if (mfu_file->type == POSIX) {
         int rc = mfu_closedir(dirp);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         int rc = daos_closedir(dirp, mfu_file);
         return rc;
     } else {
@@ -2308,7 +2308,7 @@ struct dirent* mfu_file_readdir(DIR* dirp, mfu_file_t* mfu_file)
     if (mfu_file->type == POSIX) {
         struct dirent* entry = mfu_readdir(dirp);
         return entry;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         struct dirent* entry = daos_readdir(dirp, mfu_file);
         return entry;
     } else {
@@ -2323,7 +2323,7 @@ ssize_t mfu_file_llistxattr(const char* path, char* list, size_t size, mfu_file_
     if (mfu_file->type == POSIX) {
         ssize_t rc = mfu_llistxattr(path, list, size);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         ssize_t rc = daos_llistxattr(path, list, size, mfu_file);
         return rc;
     } else {
@@ -2407,7 +2407,7 @@ ssize_t mfu_file_listxattr(const char* path, char* list, size_t size, mfu_file_t
     if (mfu_file->type == POSIX) {
         ssize_t rc = mfu_listxattr(path, list, size);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         ssize_t rc = daos_listxattr(path, list, size, mfu_file);
         return rc;
     } else {
@@ -2489,7 +2489,7 @@ ssize_t mfu_file_lgetxattr(const char* path, const char* name, void* value, size
    if (mfu_file->type == POSIX) {
         ssize_t rc = mfu_lgetxattr(path, name, value, size);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         ssize_t rc = daos_lgetxattr(path, name, value, size, mfu_file);
         return rc;
     } else {
@@ -2570,7 +2570,7 @@ ssize_t mfu_file_getxattr(const char* path, const char* name, void* value, size_
    if (mfu_file->type == POSIX) {
         ssize_t rc = mfu_getxattr(path, name, value, size);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         ssize_t rc = daos_getxattr(path, name, value, size, mfu_file);
         return rc;
     } else {
@@ -2651,7 +2651,7 @@ int mfu_file_lsetxattr(const char* path, const char* name, const void* value, si
     if (mfu_file->type == POSIX) {
         int rc = mfu_lsetxattr(path, name, value, size, flags);
         return rc;
-    } else if (mfu_file->type == DAOS) {
+    } else if (mfu_file->type == DFS) {
         int rc = daos_lsetxattr(path, name, value, size, flags, mfu_file);
         return rc;
     } else {

--- a/src/common/mfu_io.h
+++ b/src/common/mfu_io.h
@@ -133,6 +133,11 @@ int mfu_lsetxattr(const char* path, const char* name, const void* value, size_t 
 int daos_lsetxattr(const char* path, const char* name, const void* value, size_t size, int flags,
                            mfu_file_t* mfu_file);
 
+/* calls realpath */
+char* mfu_file_realpath(const char* path, char* resolved_path, mfu_file_t* mfu_file);
+char* mfu_realpath(const char* path, char* resolved_path);
+char* daos_realpath(const char* path, char* resolved_path, mfu_file_t* mfu_file);
+
 /*****************************
  * Links
  ****************************/

--- a/src/common/mfu_param_path.c
+++ b/src/common/mfu_param_path.c
@@ -629,7 +629,7 @@ static void mfu_param_path_free_list(uint64_t num, mfu_param_path* params)
     return;
 }
 
-void mfu_param_path_set_all(uint64_t num, const char** paths, mfu_param_path* params)
+void mfu_param_path_set_all(uint64_t num, const char** paths, mfu_param_path* params, mfu_file_t* mfu_file)
 {
     /* get our rank and number of ranks */
     int rank, ranks;
@@ -685,7 +685,7 @@ void mfu_param_path_set_all(uint64_t num, const char** paths, mfu_param_path* pa
             param->path = mfu_path_strdup_abs_reduce_str(path);
 
             /* get stat info for simplified path */
-            if (mfu_lstat(param->path, &param->path_stat) == 0) {
+            if (mfu_file_lstat(param->path, &param->path_stat, mfu_file) == 0) {
                 param->path_stat_valid = 1;
             }
 
@@ -696,12 +696,12 @@ void mfu_param_path_set_all(uint64_t num, const char** paths, mfu_param_path* pa
 
             /* resolve any symlinks */
             char target[PATH_MAX];
-            if (realpath(path, target) != NULL) {
+            if (mfu_file_realpath(path, target, mfu_file) != NULL) {
                 /* make a copy of resolved name */
                 param->target = MFU_STRDUP(target);
 
                 /* get stat info for resolved path */
-                if (mfu_lstat(param->target, &param->target_stat) == 0) {
+                if (mfu_file_lstat(param->target, &param->target_stat, mfu_file) == 0) {
                     param->target_stat_valid = 1;
                 }
             }
@@ -785,9 +785,9 @@ void mfu_param_path_free_all(uint64_t num, mfu_param_path* params)
 }
 
 /* set fields in param according to path */
-void mfu_param_path_set(const char* path, mfu_param_path* param)
+void mfu_param_path_set(const char* path, mfu_param_path* param, mfu_file_t* mfu_file)
 {
-    mfu_param_path_set_all(1, &path, param);
+    mfu_param_path_set_all(1, &path, param, mfu_file);
     return;
 }
 

--- a/src/common/mfu_param_path.c
+++ b/src/common/mfu_param_path.c
@@ -428,7 +428,7 @@ void mfu_param_path_check_copy(uint64_t num, const mfu_param_path* paths,
     /* just have rank 0 check */
     if(rank == 0) {
         /* DAOS-specific error checks*/
-        if (mfu_src_file->type == DAOS || mfu_dst_file->type == DAOS) {
+        if (mfu_src_file->type == DFS || mfu_dst_file->type == DFS) {
             if (num != 1) {
                 MFU_LOG(MFU_LOG_ERR, "Only one source can be specified when using DAOS");
                 valid = 0;

--- a/src/common/mfu_param_path.h
+++ b/src/common/mfu_param_path.h
@@ -54,7 +54,7 @@ typedef struct mfu_param_path_t {
 
 /* options passed to I/O functions that tell them which backend filesystem to use */
 typedef struct {
-    enum                 {POSIX, DAOS} type;
+    enum                 {POSIX, DFS, DAOS} type;
     int                  fd;
 #ifdef DAOS_SUPPORT
     /* DAOS specific variables for I/O */

--- a/src/common/mfu_param_path.h
+++ b/src/common/mfu_param_path.h
@@ -66,7 +66,7 @@ typedef struct {
 } mfu_file_t;
 
 /* set fields in param according to path */
-void mfu_param_path_set(const char* path, mfu_param_path* param);
+void mfu_param_path_set(const char* path, mfu_param_path* param, mfu_file_t* mfu_file);
 
 /* free memory associated with param */
 void mfu_param_path_free(mfu_param_path* param);
@@ -75,7 +75,7 @@ void mfu_param_path_free(mfu_param_path* param);
  * the number of paths is specified in num,
  * paths is an array of char* of length num pointing to the input paths,
  * params is an array of length num to hold output */
-void mfu_param_path_set_all(uint64_t num, const char** paths, mfu_param_path* params);
+void mfu_param_path_set_all(uint64_t num, const char** paths, mfu_param_path* params, mfu_file_t* mfu_file);
 
 /* free resources allocated in call to mfu_param_path_set_all */
 void mfu_param_path_free_all(uint64_t num, mfu_param_path* params);

--- a/src/dchmod/dchmod.c
+++ b/src/dchmod/dchmod.c
@@ -168,6 +168,9 @@ int main(int argc, char** argv)
         usage = 1;
     }
 
+    /* create new mfu_file object */    
+    mfu_file_t* mfu_file = mfu_file_new();
+
     /* paths to walk come after the options */
     int numpaths = 0;
     mfu_param_path* paths = NULL;
@@ -183,7 +186,7 @@ int main(int argc, char** argv)
 
         /* process each path */
         const char** argpaths = (const char**)(&argv[optind]);
-        mfu_param_path_set_all(numpaths, argpaths, paths);
+        mfu_param_path_set_all(numpaths, argpaths, paths, mfu_file);
 
         /* advance to next set of options */
         optind += numpaths;
@@ -221,6 +224,7 @@ int main(int argc, char** argv)
         if (rank == 0) {
             print_usage();
         }
+        mfu_file_delete(&mfu_file);
         mfu_finalize();
         MPI_Finalize();
         return 1;
@@ -228,9 +232,6 @@ int main(int argc, char** argv)
 
     /* create an empty file list */
     mfu_flist flist = mfu_flist_new();
-
-    /* create new mfu_file object */
-    mfu_file_t* mfu_file = mfu_file_new();
 
     /* flag used to check if permissions need to be
      * set on the walk */

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -2217,12 +2217,16 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    /* create new mfu_file objects */
+    mfu_file_t* mfu_src_file = mfu_file_new();
+    mfu_file_t* mfu_dst_file = mfu_file_new();
+
     /* allocate space for each path */
     mfu_param_path* paths = (mfu_param_path*) MFU_MALLOC((size_t)numargs * sizeof(mfu_param_path));
 
     /* process each path */
     const char** argpaths = (const char**)(&argv[optind]);
-    mfu_param_path_set_all(numargs, argpaths, paths);
+    mfu_param_path_set_all(numargs, argpaths, paths, mfu_src_file);
 
     /* advance to next set of options */
     optind += numargs;
@@ -2234,10 +2238,6 @@ int main(int argc, char **argv)
     /* create an empty file list */
     mfu_flist flist1 = mfu_flist_new();
     mfu_flist flist2 = mfu_flist_new();
-
-    /* create new mfu_file objects */
-    mfu_file_t* mfu_src_file = mfu_file_new();
-    mfu_file_t* mfu_dst_file = mfu_file_new();
 
     if (rank == 0) {
         MFU_LOG(MFU_LOG_INFO, "Walking source path");

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -469,8 +469,7 @@ int main(int argc, char** argv)
     else {
         /* take a snapshot and walk container to get list of objects,
          * returns epoch number of snapshot */
-        daos_epoch_t epoch;
-        int tmp_rc = mfu_flist_walk_daos(daos_args, &epoch, flist);
+        int tmp_rc = mfu_flist_walk_daos(daos_args, flist);
         if (tmp_rc != 0) {
             rc = 1;
         }
@@ -491,10 +490,11 @@ int main(int argc, char** argv)
         }
 
         /* destroy snapshot after copy */
+        /* TODO consider moving this into mfu_flist_copy_daos */
         if (rank == 0) {
             daos_epoch_range_t epr;
-            epr.epr_lo = epoch;
-            epr.epr_hi = epoch;
+            epr.epr_lo = daos_args->epc;
+            epr.epr_hi = daos_args->epc;
             rc = daos_cont_destroy_snap(daos_args->src_coh, epr, NULL);
             if (rc != 0) {
                 MFU_LOG(MFU_LOG_ERR, "DAOS destroy snapshot failed: ", MFU_ERRF,

--- a/src/dcp1/handle_args.c
+++ b/src/dcp1/handle_args.c
@@ -324,23 +324,31 @@ void DCOPY_parse_path_args(char** argv, \
     size_t src_params_bytes = ((size_t) num_src_params) * sizeof(mfu_param_path);
     src_params = (mfu_param_path*) MFU_MALLOC(src_params_bytes);
 
+    /* create new mfu_file objects */
+    mfu_file_t* mfu_src_file = mfu_file_new();
+    mfu_file_t* mfu_dst_file = mfu_file_new();
+
     /* record standardized paths and stat info for each source */
     int opt_index;
     for(opt_index = optind_local; opt_index < last_arg_index; opt_index++) {
         char* path = argv[opt_index];
         int idx = opt_index - optind_local;
-        mfu_param_path_set(path, &src_params[idx]);
+        mfu_param_path_set(path, &src_params[idx], mfu_src_file);
     }
 
     /* standardize destination path */
     const char* dstpath = argv[last_arg_index];
-    mfu_param_path_set(dstpath, &dest_param);
+    mfu_param_path_set(dstpath, &dest_param, mfu_dst_file);
 
     /* copy the destination path to user opts structure */
     DCOPY_user_opts.dest_path = MFU_STRDUP(dest_param.path);
 
     /* check that source and destinations are ok */
     DCOPY_check_paths();
+
+    /* delete file objects */
+    mfu_file_delete(&mfu_src_file);
+    mfu_file_delete(&mfu_dst_file);
 }
 
 /* frees resources allocated in call to parse_path_args() */

--- a/src/drm/drm.c
+++ b/src/drm/drm.c
@@ -197,6 +197,9 @@ int main(int argc, char** argv)
         usage = 1;
     }
 
+    /* create new mfu_file objects */
+    mfu_file_t* mfu_file = mfu_file_new();
+
     /* paths to walk come after the options */
     int numpaths = 0;
     mfu_param_path* paths = NULL;
@@ -212,7 +215,7 @@ int main(int argc, char** argv)
 
         /* process each path */
         const char** argpaths = (const char**)(&argv[optind]);
-        mfu_param_path_set_all(numpaths, argpaths, paths);
+        mfu_param_path_set_all(numpaths, argpaths, paths, mfu_file);
 
         /* advance to next set of options */
         optind += numpaths;
@@ -249,6 +252,7 @@ int main(int argc, char** argv)
         if (rank == 0) {
             print_usage();
         }
+        mfu_file_delete(&mfu_file);
         mfu_finalize();
         MPI_Finalize();
         return 1;
@@ -256,9 +260,6 @@ int main(int argc, char** argv)
 
     /* create an empty file list */
     mfu_flist flist = mfu_flist_new();
-
-    /* create new mfu_file objects */
-    mfu_file_t* mfu_file = mfu_file_new();
 
     /* get our list of files, either by walking or reading an
      * input file */

--- a/src/dsh/dsh.c
+++ b/src/dsh/dsh.c
@@ -1816,7 +1816,7 @@ int main(int argc, char** argv)
 
         /* process each path */
         const char** argpaths = (const char**)(&argv[optind]);
-        mfu_param_path_set_all(numpaths, argpaths, paths);
+        mfu_param_path_set_all(numpaths, argpaths, paths, mfu_src_file);
 
         /* advance to next set of options */
         optind += numpaths;
@@ -1839,6 +1839,7 @@ int main(int argc, char** argv)
         if (rank == 0) {
             print_usage();
         }
+        mfu_file_delete(&mfu_src_file);
         MPI_Finalize();
         return 0;
     }

--- a/src/dsync/dsync.c
+++ b/src/dsync/dsync.c
@@ -3030,12 +3030,16 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    /* create new mfu_file objects */
+    mfu_file_t* mfu_src_file = mfu_file_new();
+    mfu_file_t* mfu_dst_file = mfu_file_new();
+
     /* allocate space for each path */
     mfu_param_path* paths = (mfu_param_path*) MFU_MALLOC((size_t)numargs * sizeof(mfu_param_path));
 
     /* process each path */
     const char** argpaths = (const char**)(&argv[optind]);
-    mfu_param_path_set_all(numargs, argpaths, paths);
+    mfu_param_path_set_all(numargs, argpaths, paths, mfu_src_file);
 
     /* advance to next set of options */
     optind += numargs;
@@ -3047,10 +3051,6 @@ int main(int argc, char **argv)
     /* create an empty file list */
     mfu_flist flist_tmp_src = mfu_flist_new();
     mfu_flist flist_tmp_dst = mfu_flist_new();
-
-    /* create new mfu_file objects */
-    mfu_file_t* mfu_src_file = mfu_file_new();
-    mfu_file_t* mfu_dst_file = mfu_file_new();
 
     mfu_param_path* linkpath = NULL;
     mfu_flist flist_tmp_link = MFU_FLIST_NULL;     
@@ -3074,7 +3074,7 @@ int main(int argc, char **argv)
         } else {
             /* we can use hardlinks, so set up variables for it */
             linkpath = (mfu_param_path*) MFU_MALLOC(sizeof(mfu_param_path));
-            mfu_param_path_set(options.link_dest, linkpath);
+            mfu_param_path_set(options.link_dest, linkpath, mfu_dst_file);
             flist_tmp_link = mfu_flist_new();
         }
     }

--- a/src/dtar/dtar.c
+++ b/src/dtar/dtar.c
@@ -394,11 +394,11 @@ int main(int argc, char** argv)
         mfu_param_path* paths = (mfu_param_path*) MFU_MALLOC(numpaths * sizeof(mfu_param_path));
 
         /* process each source path */
-        mfu_param_path_set_all(numpaths, pathlist, paths);
+        mfu_param_path_set_all(numpaths, pathlist, paths, mfu_src_file);
 
         /* standardize destination path */
         mfu_param_path destpath;
-        mfu_param_path_set(opts_tarfile, &destpath);
+        mfu_param_path_set(opts_tarfile, &destpath, mfu_src_file);
 
         /* if we have an existing archive, it is deleted in check_archive so that we don't
          * walk it to be included as an entry of the archive itself in the target archive
@@ -440,7 +440,7 @@ int main(int argc, char** argv)
             char fname1[50];
             strncpy(fname1, opts_tarfile, 50);
             strncpy(fname, opts_tarfile, 50);
-            if ((stat(strcat(fname, ".bz2"), &st) == 0)) {
+            if ((mfu_file_stat(strcat(fname, ".bz2"), &st, mfu_src_file) == 0)) {
                 if (rank == 0) {
                     MFU_LOG(MFU_LOG_INFO, "Output file already exists: '%s'", fname);
                 }
@@ -469,7 +469,7 @@ int main(int argc, char** argv)
             size_t len = strlen(fname_out);
             fname_out[len - 4] = '\0';
             struct stat st;
-            if ((stat(fname_out, &st) == 0)) {
+            if ((mfu_file_stat(fname_out, &st, mfu_src_file) == 0)) {
                 if (rank == 0) {
                     MFU_LOG(MFU_LOG_ERR, "Output file already exists '%s'", fname_out);
                 }

--- a/src/dwalk/dwalk.c
+++ b/src/dwalk/dwalk.c
@@ -452,6 +452,9 @@ int main(int argc, char** argv)
         usage = 1;
     }
 
+    /* create new mfu_file object */
+    mfu_file_t* mfu_file = mfu_file_new();
+
     /* paths to walk come after the options */
     int numpaths = 0;
     mfu_param_path* paths = NULL;
@@ -467,7 +470,7 @@ int main(int argc, char** argv)
 
         /* process each path */
         char** p = &argv[optind];
-        mfu_param_path_set_all((uint64_t)numpaths, (const char**)p, paths);
+        mfu_param_path_set_all((uint64_t)numpaths, (const char**)p, paths, mfu_file);
         optind += numpaths;
 
         /* don't allow user to specify input file with walk */
@@ -567,6 +570,8 @@ int main(int argc, char** argv)
         if (rank == 0) {
             print_usage();
         }
+        mfu_file_delete(&mfu_file);
+        mfu_finalize();
         MPI_Finalize();
         return 0;
     }
@@ -576,9 +581,6 @@ int main(int argc, char** argv)
 
     /* create an empty file list with default values */
     mfu_flist flist = mfu_flist_new();
-
-    /* create new mfu_file object */
-    mfu_file_t* mfu_file = mfu_file_new();
 
     if (walk) {
         /* walk list of input paths */


### PR DESCRIPTION
- `dcp`
  - Added a missing daos_cleanup() call
- `mfu_param_path_set` and `mfu_param_path_set_all`
  - Added the argument mfu_file
- Generally changed some functions to use the mfu_file
version, since mfu_file_t was introduced.


Also broke DAOS type into DFS and DAOS

- Changed previous usage of DAOS to DFS
- Added "new" DAOS for non-DFS API
- Added --daos-api to dcp
- Removed is_posix_copy references
  - Use is_daos_copy locally in dcp
- Added compatibility checks for daos containers
- Refactored some DAOS functions
- Fixed memory leaks with setting argpaths


Closes #433 

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>