### PR TITLE
libarchive: update to version 3.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ before_install:
  - pushd ${dtcmp}
  - ./configure --with-lwgrp=/usr/local && make && sudo make install
  - popd
- - libarchive=libarchive-3.5.0
- - wget https://github.com/libarchive/libarchive/releases/download/v3.5.0/${libarchive}.tar.gz
+ - libarchive=libarchive-3.5.1
+ - wget https://github.com/libarchive/libarchive/releases/download/3.5.1/${libarchive}.tar.gz
  - tar zxvf ${libarchive}.tar.gz
  - pushd ${libarchive}
  - ./configure && make && sudo make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ LIST(APPEND MFU_EXTERNAL_LIBS ${DTCMP_LIBRARIES})
 # libarchive 3.1.2 is available on some systems,
 # but pick a newer libarchive to avoid bug with files starting with "._",
 # which is misinterpretted as a MacOS extension on Linuxlibarchive 3.1.2
-FIND_PACKAGE(LibArchive 3.5.0 REQUIRED)
+FIND_PACKAGE(LibArchive 3.5.1 REQUIRED)
 INCLUDE_DIRECTORIES(${LibArchive_INCLUDE_DIRS})
 LIST(APPEND MFU_EXTERNAL_LIBS ${LibArchive_LIBRARIES})
 

--- a/doc/rst/build.rst
+++ b/doc/rst/build.rst
@@ -48,7 +48,7 @@ Then to install the dependencies, run the following commands:
      wget https://github.com/hpc/libcircle/releases/download/v0.3/libcircle-0.3.0.tar.gz
      wget https://github.com/llnl/lwgrp/releases/download/v1.0.3/lwgrp-1.0.3.tar.gz
      wget https://github.com/llnl/dtcmp/releases/download/v1.1.1/dtcmp-1.1.1.tar.gz
-     wget https://github.com/libarchive/libarchive/releases/download/v3.5.0/libarchive-3.5.0.tar.gz
+     wget https://github.com/libarchive/libarchive/releases/download/3.5.1/libarchive-3.5.1.tar.gz
      
      tar -zxf libcircle-0.3.0.tar.gz
      cd libcircle-0.3.0
@@ -68,8 +68,8 @@ Then to install the dependencies, run the following commands:
        make install
      cd ..
 
-     tar -zxf libarchive-3.5.0.tar.gz
-     cd libarchive-3.5.0
+     tar -zxf libarchive-3.5.1.tar.gz
+     cd libarchive-3.5.1
        ./configure --prefix=$installdir
        make install
      cd ..


### PR DESCRIPTION

libarchive 3.5.1 fixes some compile issues from 3.5.0.
I suggest using 3.5.1 in the documentation, etc. so other users don't run into compile issues that are fixed in 3.5.1.

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>