### PR TITLE
daos: dsync and dcmp support

### DIFF
--- a/doc/rst/dcmp.1.rst
+++ b/doc/rst/dcmp.1.rst
@@ -49,6 +49,19 @@ OPTIONS
    "GB" can immediately follow the number without spaces (eg. 64MB).
    The default chunksize is 1MB.
 
+.. option:: --daos-prefix PREFIX
+
+   Specify the DAOS prefix to be used. This is only necessary
+   if copying a subset of a POSIX container in DAOS using a
+   Unified Namespace path.
+
+.. option:: --daos-api API
+
+   Specify the DAOS API to be used. By default, the API is automatically
+   determined based on the container type, where POSIX containers use the
+   DFS API, and all other containers use the DAOS object API.
+   Values must be in {DFS, DAOS}.
+
 .. option:: -s, --direct
 
    Use O_DIRECT to avoid caching file data.

--- a/doc/rst/dcp.1.rst
+++ b/doc/rst/dcp.1.rst
@@ -23,14 +23,14 @@ OPTIONS
 
    Set the I/O buffer to be SIZE bytes.  Units like "MB" and "GB" may
    immediately follow the number without spaces (eg. 8MB). The default
-   blocksize is 1MB.
+   blocksize is 64MB.
 
 .. option:: --chunksize SIZE
 
    Multiple processes copy a large file in parallel by dividing it into chunks.
    Set chunk to be at minimum SIZE bytes.  Units like "MB" and
    "GB" can immediately follow the number without spaces (eg. 64MB).
-   The default chunksize is 1MB.
+   The default chunksize is 64MB.
 
 .. option:: --daos-prefix PREFIX
 

--- a/doc/rst/dsync.1.rst
+++ b/doc/rst/dsync.1.rst
@@ -39,6 +39,19 @@ OPTIONS
    "GB" can immediately follow the number without spaces (eg. 64MB).
    The default chunksize is 64MB.
 
+.. option:: --daos-prefix PREFIX
+
+   Specify the DAOS prefix to be used. This is only necessary
+   if copying a subset of a POSIX container in DAOS using a
+   Unified Namespace path.
+
+.. option:: --daos-api API
+
+   Specify the DAOS API to be used. By default, the API is automatically
+   determined based on the container type, where POSIX containers use the
+   DFS API, and all other containers use the DAOS object API.
+   Values must be in {DFS, DAOS}.
+
 .. option:: -c, --contents
 
    Compare files byte-by-byte rather than checking size and mtime

--- a/doc/rst/dsync.1.rst
+++ b/doc/rst/dsync.1.rst
@@ -30,14 +30,14 @@ OPTIONS
 
    Set the I/O buffer to be SIZE bytes.  Units like "MB" and "GB" may
    immediately follow the number without spaces (eg. 8MB). The default
-   blocksize is 1MB.
+   blocksize is 64MB.
 
 .. option:: --chunksize SIZE
 
    Multiple processes copy a large file in parallel by dividing it into chunks.
    Set chunk to be at minimum SIZE bytes.  Units like "MB" and
    "GB" can immediately follow the number without spaces (eg. 64MB).
-   The default chunksize is 1MB.
+   The default chunksize is 64MB.
 
 .. option:: -c, --contents
 
@@ -57,7 +57,7 @@ OPTIONS
 
    Do not follow symbolic links in source paths. Effectviely allows
    symbolic links to be copied when the link target is not valid
-   or there is not permission to read the link's target.
+   or there is not permission to read the link's target.
 
 .. option:: -s, --direct
 

--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -544,7 +544,7 @@ void mfu_flist_metadata_apply(
 
 /* unlink all items in flist,
  * if traceless=1, restore timestamps on parent directories after unlinking children */
-void mfu_flist_unlink(mfu_flist flist, bool traceless);
+void mfu_flist_unlink(mfu_flist flist, bool traceless, mfu_file_t* mfu_file);
 
 typedef struct {
     uid_t getuid;   /* result from getuid */

--- a/src/common/mfu_io.h
+++ b/src/common/mfu_io.h
@@ -99,7 +99,9 @@ int daos_mknod(const char* path, mode_t mode, dev_t dev, mfu_file_t* mfu_file);
 int mfu_mknod(const char* path, mode_t mode, dev_t dev);
 
 /* call remove, retry a few times on EINTR or EIO */
+int mfu_file_remove(const char* path, mfu_file_t* mfu_file);
 int mfu_remove(const char* path);
+int daos_remove(const char* path, mfu_file_t* mfu_file);
 
 /* read directory entry, retry a few times on ENOENT, EIO, or EINTR */
 struct dirent* mfu_file_readdir(DIR* dirp, mfu_file_t* mfu_file);
@@ -160,7 +162,7 @@ int mfu_symlink(const char* oldpath, const char* newpath);
  ****************************/
 
 /* open file with specified flags and mode, retry open a few times on failure */
-void mfu_file_open(const char* file, int flags, mfu_file_t* mfu_file, ...);
+int mfu_file_open(const char* file, int flags, mfu_file_t* mfu_file, ...);
 int daos_open(const char* file, int flags, mode_t mode, mfu_file_t* mfu_file);
 int mfu_open(const char* file, int flags, ...);
 
@@ -226,7 +228,9 @@ int mfu_mkdir(const char* dir, mode_t mode);
 int daos_mkdir(const char* dir, mode_t mode, mfu_file_t* mfu_file);
 
 /* remove directory, retry a few times on EINTR or EIO */
+int mfu_file_rmdir(const char* dir, mfu_file_t* mfu_file);
 int mfu_rmdir(const char* dir);
+int daos_rmdir(const char* dir, mfu_file_t* mfu_file);
 
 /* open directory, retry a few times on EINTR or EIO */
 DIR* mfu_file_opendir(const char* dir, mfu_file_t* mfu_file);

--- a/src/common/mfu_util.h
+++ b/src/common/mfu_util.h
@@ -245,7 +245,9 @@ int mfu_compare_contents(
     mfu_copy_opts_t* opts,    /* IN  - options to use in compare/copy */
     uint64_t* bytes_read,     /* OUT - number of bytes read (src + dest) */
     uint64_t* bytes_written,  /* OUT - number of bytes written to dest */
-    mfu_progress* prg         /* IN  - progress message structure */
+    mfu_progress* prg,        /* IN  - progress message structure */
+    mfu_file_t* mfu_src_file, /* IN  - I/O filesystem functions to use for source */
+    mfu_file_t* mfu_dst_file  /* IN  - I/O filesystem functions to use for destination */
 );
 
 /* uses the lustre api to obtain stripe count and stripe size of a file */

--- a/src/drm/drm.c
+++ b/src/drm/drm.c
@@ -292,7 +292,7 @@ int main(int argc, char** argv)
         mfu_flist_print(srclist);
     } else {
         /* remove files */
-        mfu_flist_unlink(srclist, traceless);
+        mfu_flist_unlink(srclist, traceless, mfu_file);
     }
 
     /* write data to cache file */

--- a/src/dsh/dsh.c
+++ b/src/dsh/dsh.c
@@ -2000,7 +2000,7 @@ int main(int argc, char** argv)
                 int inclusive = 1;
                 mfu_flist filtered, leftover;
                 filter_files_path(flist, remove_path, inclusive, &filtered, &leftover);
-                mfu_flist_unlink(filtered, false);
+                mfu_flist_unlink(filtered, false, mfu_src_file);
                 mfu_flist_free(&filtered);
 
                 /* to update our list after removing files above, set flist


### PR DESCRIPTION
Added daos support to dsync.
Added daos support to dcmp.

`dsync.c`
- Added daos options
- Modified IO calls to use `mfu_file_*`

`dcmp.c`
-- Added daos options

`mfu_io`
- Added `mfu_file_rmdir` and `daos_rmdir`

`mfu_flist_unlink`
- Added `mfu_file_t` param

`mfu_daos.c`
- Fixed error checking for DAOS args