### PR TITLE
bump shared library version to 3.0.0

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Version for the shared mfu library
-set(MFU_VERSION_MAJOR 2) # Incompatible API changes
+set(MFU_VERSION_MAJOR 3) # Incompatible API changes
 set(MFU_VERSION_MINOR 0) # Backwards-compatible functionality
 set(MFU_VERSION_PATCH 0) # Backwards-compatible fixes
 set(MFU_VERSION ${MFU_VERSION_MAJOR}.${MFU_VERSION_MINOR}.${MFU_VERSION_PATCH})


### PR DESCRIPTION
Bump shared library version to 3.0.0 due to previous commits.

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>