### PR TITLE
dcmp, dsync: split on copy_opts chunk size rather than hardcoded value

### DIFF
--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -783,8 +783,8 @@ static int dcmp_strmap_compare_data(
          MFU_LOG(MFU_LOG_INFO, "Comparing file contents");
     }
 
-    /* get chunk size for copying files (just hard-coded for now) */
-    uint64_t chunk_size = 1024 * 1024;
+    /* get chunk size for copying files */
+    uint64_t chunk_size = copy_opts->chunk_size;
 
     /* get the linked list of file chunks for the src and dest */
     mfu_file_chunk* src_head = mfu_file_chunk_list_alloc(src_compare_list, chunk_size);

--- a/src/dsync/dsync.c
+++ b/src/dsync/dsync.c
@@ -715,7 +715,7 @@ static void dsync_strmap_compare_data_link_dest(
     int rc = 0;
 
     /* get chunk size for copying files (just hard-coded for now) */
-    uint64_t chunk_size = 1024 * 1024;
+    uint64_t chunk_size = copy_opts->chunk_size;
 
     /* get the linked list of file chunks for the src and dest */
     mfu_file_chunk* src_head = mfu_file_chunk_list_alloc(src_compare_list, chunk_size);
@@ -834,7 +834,7 @@ static int dsync_strmap_compare_data(
     int rc = 0;
 
     /* get chunk size for copying files (just hard-coded for now) */
-    uint64_t chunk_size = 1024 * 1024;
+    uint64_t chunk_size = copy_opts->chunk_size;
 
     /* get the linked list of file chunks for the src and dest */
     mfu_file_chunk* src_head = mfu_file_chunk_list_alloc(src_compare_list, chunk_size);


### PR DESCRIPTION
When splitting files into chunks, switch to slice files based on ``copy_opts->chunk_size`` instead of a hardcoded value of 1MB.  In addition to being more flexible and consistent, the hard coded value failed a self-imposed constraint when enabling O_DIRECT.