### PR TITLE
daos: dsync support for daos objects

### DIFF
--- a/src/common/mfu_daos.h
+++ b/src/common/mfu_daos.h
@@ -34,7 +34,8 @@ typedef struct {
     char* src_path;        /* allocated src path */
     char* dst_path;        /* allocated dst path */
     daos_api_t api;        /* API to use */
-    daos_epoch_t epc;      /* src container epoch */
+    daos_epoch_t src_epc;  /* src container epoch */
+    daos_epoch_t dst_epc;  /* dst container epoch */
 } daos_args_t;
 
 /* Return a newly allocated daos_args_t structure.
@@ -77,15 +78,48 @@ int daos_cleanup(
   mfu_file_t* mfu_dst_file
 );
 
+int mfu_daos_map_oid_fn(
+  mfu_flist flist,
+  uint64_t idx,
+  int ranks,
+  void *args);
+
+/* Locally copy an mfu_flist to a mfu_file_chunk list. */
+mfu_file_chunk* mfu_daos_file_chunk_list_create(
+  mfu_flist list);
+
+/* Compare two objects and optionally overwrite dest with source.
+ * returns -1 on error, 0 if equal, 1 if different */
+int mfu_daos_compare_contents(
+  daos_args_t* da,                  /* DAOS args */
+  uint64_t src_oid_lo,              /* source oid.lo */
+  uint64_t src_oid_hi,              /* source oid.hi */
+  uint64_t dst_oid_lo,              /* destination oid.lo */
+  uint64_t dst_oid_hi,              /* destination oid.hi */
+  int overwrite,                    /* whether to replace dest with source contents (1) or not (0) */ 
+  uint64_t* count_bytes_read,       /* number of bytes read (src + dest) */
+  uint64_t* count_bytes_written,    /* number of bytes written to dest */
+  mfu_progress* prg,                /* progress message structure */
+  mfu_file_t* mfu_src_file,
+  mfu_file_t* mfu_dst_file);
+
 /* walk objects in daos and insert to given flist */
 int mfu_flist_walk_daos(
-    daos_args_t* da,
-    mfu_flist flist
+  daos_args_t* da,
+  daos_handle_t coh,
+  daos_epoch_t* epoch,
+  mfu_flist flist
 );
 
 /* copy objects in flist to destination listed in daos args,
  * copies DAOS data at object level (non-posix) */
 int mfu_flist_copy_daos(
-    daos_args_t* da,
-    mfu_flist flist
+  daos_args_t* da,
+  mfu_flist flist
 );
+
+/* Punch each object in the flist.
+ * Returns -1 on failure, 0 on success. */
+int mfu_daos_flist_punch(
+  daos_handle_t coh,
+  mfu_flist flist);

--- a/src/common/mfu_flist.c
+++ b/src/common/mfu_flist.c
@@ -345,6 +345,11 @@ static void list_insert_copy(flist_t* flist, elem_t* src)
     elem->ctime_nsec = src->ctime_nsec;
     elem->size       = src->size;
 
+#ifdef DAOS_SUPPORT
+    elem->obj_id_lo  = src->obj_id_lo;
+    elem->obj_id_hi  = src->obj_id_hi;
+#endif
+
     /* append element to tail of linked list */
     mfu_flist_insert_elem(flist, elem);
 
@@ -1010,6 +1015,28 @@ void mfu_flist_file_set_oid(mfu_flist bflist, uint64_t idx, daos_obj_id_t oid)
         elem->obj_id_hi = oid.hi;
     }
     return;
+}
+
+uint64_t mfu_flist_file_get_obj_id_hi(mfu_flist bflist, uint64_t idx)
+{
+    flist_t* flist = (flist_t*) bflist;
+    elem_t* elem = list_get_elem(flist, idx);
+    uint64_t oid_hi = 0;
+    if (elem != NULL) {
+        oid_hi = elem->obj_id_hi;
+    }
+    return oid_hi;
+}
+
+uint64_t mfu_flist_file_get_obj_id_lo(mfu_flist bflist, uint64_t idx)
+{
+    flist_t* flist = (flist_t*) bflist;
+    elem_t* elem = list_get_elem(flist, idx);
+    uint64_t oid_lo = 0;
+    if (elem != NULL) {
+        oid_lo = elem->obj_id_lo;
+    }
+    return oid_lo;
 }
 #endif 
 

--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -403,6 +403,8 @@ const char* mfu_flist_file_get_groupname(mfu_flist flist, uint64_t index);
 /* set properties on specified item in local flist */
 #ifdef DAOS_SUPPORT
 void mfu_flist_file_set_oid(mfu_flist flist, uint64_t index, daos_obj_id_t oid);
+uint64_t mfu_flist_file_get_obj_id_hi(mfu_flist bflist, uint64_t idx);
+uint64_t mfu_flist_file_get_obj_id_lo(mfu_flist bflist, uint64_t idx);
 #endif
 void mfu_flist_file_set_name(mfu_flist flist, uint64_t index, const char* name);
 void mfu_flist_file_set_type(mfu_flist flist, uint64_t index, mfu_filetype type);
@@ -591,6 +593,11 @@ typedef struct mfu_file_chunk_struct {
   uint64_t file_size;      /* full size of target file */
   uint64_t rank_of_owner;  /* MPI rank acting as the owner of this file */
   uint64_t index_of_owner; /* index value of file in original flist on its owner rank */
+#ifdef DAOS_SUPPORT
+  /* TODO maybe just use daos_obj_id_t? Here and in flist? */
+  uint64_t obj_id_lo;      /* DAOS oid.lo */
+  uint64_t obj_id_hi;      /* DAOS oid.hi */
+#endif
   struct mfu_file_chunk_struct* next; /* pointer to next chunk element */
 } mfu_file_chunk;
 

--- a/src/common/mfu_param_path.h
+++ b/src/common/mfu_param_path.h
@@ -52,9 +52,17 @@ typedef struct mfu_param_path_t {
     struct stat target_stat; /* stat of target path */
 } mfu_param_path;
 
+/* TODO rename all of these to MFU_FILE_TYPE_* or similar
+ * to avoid potential name conflicts */
+typedef enum {
+    POSIX,
+    DFS,
+    DAOS
+} mfu_file_type_t;
+
 /* options passed to I/O functions that tell them which backend filesystem to use */
 typedef struct {
-    enum                 {POSIX, DFS, DAOS} type;
+    mfu_file_type_t      type;
     int                  fd;
 #ifdef DAOS_SUPPORT
     /* DAOS specific variables for I/O */

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -376,16 +376,13 @@ int main(int argc, char** argv)
     }
 #endif
 
-    /* paths to walk come after the options */
-    mfu_param_path* paths = NULL;
-
     /* create an empty file list */
     mfu_flist flist = mfu_flist_new();
 
     /* Perform a POSIX copy for non-DAOS types */
     if (mfu_src_file->type != DAOS && mfu_dst_file->type != DAOS) {
         /* allocate space for each path */
-        paths = (mfu_param_path*) MFU_MALLOC((size_t)numpaths * sizeof(mfu_param_path));
+        mfu_param_path* paths = (mfu_param_path*) MFU_MALLOC((size_t)numpaths * sizeof(mfu_param_path));
 
         /* last item in the list is the destination path */
         mfu_param_path* destpath = &paths[numpaths - 1];
@@ -451,17 +448,11 @@ int main(int argc, char** argv)
             rc = 1;
         }
 
-        /* free the file list */
-        mfu_flist_free(&flist);
-
         /* free the path parameters */
         mfu_param_path_free_all(numpaths, paths);
 
         /* free memory allocated to hold params */
         mfu_free(&paths);
-
-        /* free the input file name */
-        mfu_free(&inputname);
     } 
 #ifdef DAOS_SUPPORT
     /* Perform an object-level copy for DAOS types */
@@ -512,6 +503,12 @@ int main(int argc, char** argv)
     /* Cleanup DAOS-related variables, etc. */
     daos_cleanup(daos_args, mfu_src_file, mfu_dst_file);
 #endif
+
+    /* free the file list */
+    mfu_flist_free(&flist);
+
+    /* free the input file name */
+    mfu_free(&inputname);
 
     /* free the copy options */
     mfu_copy_opts_delete(&mfu_copy_opts);


### PR DESCRIPTION
Adds support for DAOS objects in dsync.
Functionally, this should work, although these points will be tackled at a later time:
- General performance improvements
- Updated/improved metrics for DAOS objects

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>