### PR TITLE
daos: simplify and enhance path parsing

### DIFF
--- a/src/common/mfu_daos.h
+++ b/src/common/mfu_daos.h
@@ -135,6 +135,9 @@ struct hdf5_args {
 };
 #endif
 
+/* Check whether a uuid is valid */
+bool daos_uuid_valid(const uuid_t uuid);
+
 /* Return a newly allocated daos_args_t structure.
  * Set default values on its fields. */
 daos_args_t* daos_args_new(void);
@@ -172,8 +175,7 @@ int daos_parse_path(
     char *path,
     size_t path_len,
     uuid_t *p_uuid,
-    uuid_t *c_uuid,
-    bool daos_no_prefix
+    uuid_t *c_uuid
 );
 
 /* connect to DAOS pool,

--- a/src/daos-serialize/daos-serialize.c
+++ b/src/daos-serialize/daos-serialize.c
@@ -19,10 +19,10 @@
 void print_usage(void)
 {
     printf("\n");
-    printf("Usage: daos-serialize [options] /<pool>/<cont>\n");
+    printf("Usage: daos-serialize [options] daos://<pool>/<cont>\n");
     printf("\n");
     printf("DAOS paths can be specified as:\n");
-    printf("       /<pool>/<cont> | <UNS path>\n");
+    printf("       daos://<pool>/<cont> | <UNS path>\n");
     printf("\n");
     printf("Options:\n");
     printf("  -o  --output-path        - path to output serialized hdf5 files\n");
@@ -140,16 +140,10 @@ int main(int argc, char** argv)
 
     int len = strlen(argpaths[0]); 
 
-    /* default to no daos prefix, but allow someone to use one */
-    bool daos_no_prefix = true;
-    if (strncmp(argpaths[0], "daos://", 7) == 0) {
-        daos_no_prefix = false; 
-    }
-
     int tmp_rc;
     tmp_rc = daos_parse_path(argpaths[0], len, &daos_args->src_pool_uuid,
-                         &daos_args->src_cont_uuid, daos_no_prefix);
-    if (tmp_rc != 0 || daos_args->src_pool_uuid == NULL || daos_args->src_cont_uuid == NULL) {
+                         &daos_args->src_cont_uuid);
+    if (tmp_rc != 0 || !daos_uuid_valid(daos_args->src_pool_uuid) || !daos_uuid_valid(daos_args->src_cont_uuid)) {
         MFU_LOG(MFU_LOG_ERR, "Failed to resolve DAOS path");
          rc = 1;
     }


### PR DESCRIPTION
Fixed a bug in daos_parse_path where -1 would
be returned for a POSIX path, but should be 1.

Simplified daos_parse_path to always require the daos://
prefix for daos paths.

Remove custom pool uuid parsing, which is now handled by
duns_resolve_path.

Improve some path free's.

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>