### PR TITLE
daos: use internal IO functions

### DIFF
--- a/src/common/mfu_errors.h
+++ b/src/common/mfu_errors.h
@@ -8,6 +8,18 @@ extern "C" {
 #ifndef MFU_ERRORS_H
 #define MFU_ERRORS_H
 
+#include <errno.h>
+
+/* Given a system error code, set errno and return -1 on error */
+static inline int mfu_errno2rc(int err)
+{
+    if (err == 0) {
+        return 0;
+    }
+    errno = err;
+    return -1;
+}
+
 /* Generic error codes */
 #define MFU_ERR           1000
 #define MFU_ERR_INVAL_ARG 1001

--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -3220,8 +3220,8 @@ mfu_file_t* mfu_file_new(void)
     mfile->fd         = -1;
 #ifdef DAOS_SUPPORT
     mfile->obj        = NULL;
+    mfile->dfs_sys    = NULL;
     mfile->dfs        = NULL;
-    mfile->dfs_hash   = NULL;
 #endif
     return mfile;
 }

--- a/src/common/mfu_io.h
+++ b/src/common/mfu_io.h
@@ -37,6 +37,7 @@ extern "C" {
 #ifdef DAOS_SUPPORT
 #include <daos.h>
 #include <daos_fs.h>
+#include <daos_fs_sys.h>
 #endif
 
 #include "mfu_param_path.h"
@@ -95,7 +96,7 @@ int daos_stat(const char* path, struct stat* buf, mfu_file_t* mfu_file);
 
 /* call mknod, retry a few times on EINTR or EIO */
 int mfu_file_mknod(const char* path, mode_t mode, dev_t dev, mfu_file_t* mfu_file);
-int daos_mknod(const char* path, mode_t mode, dev_t dev, mfu_file_t* mfu_file);
+int daos_mknod(const char* path, mode_t mode, mfu_file_t* mfu_file);
 int mfu_mknod(const char* path, mode_t mode, dev_t dev);
 
 /* call remove, retry a few times on EINTR or EIO */

--- a/src/common/mfu_param_path.c
+++ b/src/common/mfu_param_path.c
@@ -537,8 +537,8 @@ void mfu_param_path_check_copy(uint64_t num, const mfu_param_path* paths,
 
             /* check that dest is writable */
             if(mfu_file_access(destpath->path, W_OK, mfu_dst_file) < 0) {
-                MFU_LOG(MFU_LOG_ERR, "Destination is not writable `%s'",
-                    destpath->path);
+                MFU_LOG(MFU_LOG_ERR, "Destination is not writable `%s' (errno=%d %s)",
+                    destpath->path, errno, strerror(errno));
                 valid = 0;
                 goto bcast;
             }
@@ -555,8 +555,8 @@ void mfu_param_path_check_copy(uint64_t num, const mfu_param_path* paths,
 
             /* check that parent is writable */
             if(mfu_file_access(parent_str, W_OK, mfu_dst_file) < 0) {
-                MFU_LOG(MFU_LOG_ERR, "Destination parent directory is not writable `%s'",
-                    parent_str);
+                MFU_LOG(MFU_LOG_ERR, "Destination parent directory is not writable `%s' (errno=%d %s)",
+                    parent_str, errno, strerror(errno));
                 valid = 0;
                 mfu_free(&parent_str);
                 goto bcast;

--- a/src/common/mfu_param_path.h
+++ b/src/common/mfu_param_path.h
@@ -58,10 +58,10 @@ typedef struct {
     int                  fd;
 #ifdef DAOS_SUPPORT
     /* DAOS specific variables for I/O */
-    daos_off_t           offset;
-    dfs_obj_t*           obj;
-    dfs_t*               dfs;
-    struct d_hash_table* dfs_hash;
+    daos_off_t           offset;  /* file offset */
+    dfs_obj_t*           obj;     /* open object handle */
+    dfs_sys_t*           dfs_sys; /* handle for high-level file operations */
+    dfs_t*               dfs;     /* handle for lower-level file operations */
 #endif
 } mfu_file_t;
 


### PR DESCRIPTION
- Replace the dfs_* IO calls with the new dfs_sys_* API.
- Return ENOSYS when not DAOS_SUPPORT.
- Added mfu_errno2rc to simplify returns from dfs_* calls.

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>