### PR TITLE
daos: fix root path bug

### DIFF
--- a/src/common/mfu_io.c
+++ b/src/common/mfu_io.c
@@ -238,13 +238,15 @@ static int parse_filename(const char* path, char** _obj_name, char** _cont_name)
                 }
 	}
 
-	*_obj_name = strdup(fname);
-	if (*_obj_name == NULL) {
-		free(*_cont_name);
-		*_cont_name = NULL;
-                rc = -ENOMEM;
-                goto out;
-	}
+    if (strcmp(fname, "/") != 0) {
+        *_obj_name = strdup(fname);
+        if (*_obj_name == NULL) {
+            free(*_cont_name);
+            *_cont_name = NULL;
+            rc = -ENOMEM;
+            goto out;
+        }
+    }
 
 out:
 	if (f1)

--- a/src/common/mfu_param_path.c
+++ b/src/common/mfu_param_path.c
@@ -372,11 +372,14 @@ char* mfu_param_path_copy_dest(const char* name, int numpaths,
     /* get number of components in source path */
     int src_components = mfu_path_components(src);
 
-    /* if copying into directory, keep last component,
+    /* if copying into directory, keep last component.
+     * if path is root, keep last component.
      * otherwise cut all components listed in source path */
     int cut = src_components;
     if (mfu_copy_opts->copy_into_dir && cut > 0) {
-        if ((mfu_copy_opts->do_sync != 1) &&
+        if (strcmp(paths[i].orig, "/") == 0) {
+            cut--;
+        } else if ((mfu_copy_opts->do_sync != 1) &&
             (paths[i].orig[strlen(paths[i].orig) - 1] != '/')) {
             cut--;
         }


### PR DESCRIPTION
- In `mfu_param_path_copy_dest`, don't cut the root path.
- In parse_filename, account for when dir and name are both "/",
  which can happen depending on the version of basename used.

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>