### PR TITLE
daos: copy user attrs and cont props on create

### DIFF
--- a/src/common/mfu_daos.h
+++ b/src/common/mfu_daos.h
@@ -236,7 +236,8 @@ int daos_connect(
   daos_handle_t* coh,
   bool connect_pool,
   bool create_cont,
-  bool require_new_cont
+  bool require_new_cont,
+  mfu_file_t* mfu_src_file
 );
 
 /* broadcast a pool or cont handle

--- a/src/daos-serialize/daos-serialize.c
+++ b/src/daos-serialize/daos-serialize.c
@@ -150,7 +150,7 @@ int main(int argc, char** argv)
     
     tmp_rc = daos_connect(rank, daos_args, daos_args->src_pool_uuid,
                           daos_args->src_cont_uuid, &daos_args->src_poh,
-                          &daos_args->src_coh, true, false, false);
+                          &daos_args->src_coh, true, false, false, NULL);
     if (tmp_rc != 0) {
         rc = 1;
     }


### PR DESCRIPTION
When creating a new DAOS container, copy the user attributes
and container properties from the src container.

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>