### PR TITLE
travis: use default xenial instead of trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 
 language: c
 


### PR DESCRIPTION
The "trusty' distro seems to be missing a public key.

The Travis documentation recommends not using Trusty, as it is EOL:
- https://docs.travis-ci.com/user/reference/trusty/

For reference, this is the difference:
- https://docs.travis-ci.com/user/reference/xenial/#differences-from-the-trusty-images

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>