### PR TITLE
daos: remove prefix from documentation and update call to duns_resolve_path

### DIFF
--- a/doc/rst/dcmp.1.rst
+++ b/doc/rst/dcmp.1.rst
@@ -49,12 +49,6 @@ OPTIONS
    "GB" can immediately follow the number without spaces (e.g. 64MB).
    The default chunksize is 4MB.
 
-.. option:: --daos-prefix PREFIX
-
-   Specify the DAOS prefix to be used. This is only necessary
-   if copying a subset of a POSIX container in DAOS using a
-   Unified Namespace path.
-
 .. option:: --daos-api API
 
    Specify the DAOS API to be used. By default, the API is automatically

--- a/doc/rst/dcp.1.rst
+++ b/doc/rst/dcp.1.rst
@@ -32,12 +32,6 @@ OPTIONS
    "GB" can immediately follow the number without spaces (e.g. 64MB).
    The default chunksize is 4MB.
 
-.. option:: --daos-prefix PREFIX
-
-   Specify the DAOS prefix to be used. This is only necessary
-   if copying a subset of a POSIX container in DAOS using a
-   Unified Namespace path.
-
 .. option:: --daos-api API
 
    Specify the DAOS API to be used. By default, the API is automatically

--- a/doc/rst/dsync.1.rst
+++ b/doc/rst/dsync.1.rst
@@ -39,12 +39,6 @@ OPTIONS
    "GB" can immediately follow the number without spaces (e.g. 64MB).
    The default chunksize is 4MB.
 
-.. option:: --daos-prefix PREFIX
-
-   Specify the DAOS prefix to be used. This is only necessary
-   if copying a subset of a POSIX container in DAOS using a
-   Unified Namespace path.
-
 .. option:: --daos-api API
 
    Specify the DAOS API to be used. By default, the API is automatically

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -42,7 +42,6 @@ static void print_usage(void)
     printf("      --bufsize <SIZE>      - IO buffer size in bytes (default " MFU_BUFFER_SIZE_STR ")\n");
     printf("      --chunksize <SIZE>    - minimum work size per task in bytes (default " MFU_CHUNK_SIZE_STR ")\n");
 #ifdef DAOS_SUPPORT
-    printf("      --daos-prefix         - DAOS prefix for unified namespace path\n");
     printf("      --daos-api            - DAOS API in {DFS, DAOS} (default uses DFS for POSIX containers)\n");
 #endif
     printf("  -s, --direct              - open files with O_DIRECT\n");

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -80,7 +80,6 @@ void print_usage(void)
     printf("  -b, --bufsize <SIZE>     - IO buffer size in bytes (default " MFU_BUFFER_SIZE_STR ")\n");
     printf("  -k, --chunksize <SIZE>   - work size per task in bytes (default " MFU_CHUNK_SIZE_STR ")\n");
 #ifdef DAOS_SUPPORT
-    printf("      --daos-prefix        - DAOS prefix for unified namespace path\n");
     printf("      --daos-api           - DAOS API in {DFS, DAOS} (default uses DFS for POSIX containers)\n");
 #ifdef HDF5_SUPPORT
     printf("      --daos-preserve      - preserve DAOS container properties and user attributes, a filename "

--- a/src/dsync/dsync.c
+++ b/src/dsync/dsync.c
@@ -64,7 +64,6 @@ static void print_usage(void)
     printf("      --bufsize <SIZE>    - IO buffer size in bytes (default " MFU_BUFFER_SIZE_STR ")\n");
     printf("      --chunksize <SIZE>  - minimum work size per task in bytes (default " MFU_CHUNK_SIZE_STR ")\n");
 #ifdef DAOS_SUPPORT
-    printf("      --daos-prefix       - DAOS prefix for unified namespace path \n");
     printf("      --daos-api          - DAOS API in {DFS, DAOS} (default uses DFS for POSIX containers)\n");
 #endif
     printf("  -c, --contents          - read and compare file contents rather than compare size and mtime\n");


### PR DESCRIPTION
This just removes the daos-prefix option from the documentation
because it is no longer necessary after a recent DAOS PR
that allows passing a subset of a UNS path to duns_resolve_path.
The option is removed from the documentation but not removed
from the code in order to preserve backwards compatibility with
the DAOS tests for the datamover.

The call to duns_resolve_path was updated in the case that the
last directory or file in the UNS path does not yet exist, since
it doesn't recurse the rest of the paths in the directory tree
in that case.

Signed-off-by: Danielle Sikich <danielle.sikich@intel.com>