### PR TITLE
daos: update setting of container label

### DIFF
--- a/src/common/mfu_daos.h
+++ b/src/common/mfu_daos.h
@@ -210,7 +210,6 @@ int daos_cont_deserialize_hdlr(
 int daos_cont_deserialize_connect(
     daos_args_t *daos_args,
     struct hdf5_args *hdf5,
-    daos_prop_t *prop,
     daos_cont_layout_t *cont_type
 );
 
@@ -235,8 +234,10 @@ int cont_serialize_props(struct hdf5_args *hdf5,
 int cont_serialize_usr_attrs(struct hdf5_args *hdf5,
                              daos_handle_t cont);
 
-int cont_deserialize_all_props(struct hdf5_args *hdf5, daos_prop_t *prop, 
-                               daos_cont_layout_t *cont_type);
+int cont_deserialize_all_props(struct hdf5_args *hdf5,
+                               daos_prop_t **prop, 
+                               daos_cont_layout_t *cont_type,
+                               daos_handle_t poh);
 
 int cont_deserialize_usr_attrs(struct hdf5_args* hdf5,
                                daos_handle_t coh);

--- a/src/daos-deserialize/daos-deserialize.c
+++ b/src/daos-deserialize/daos-deserialize.c
@@ -272,7 +272,6 @@ int main(int argc, char** argv)
         uint64_t                files_generated = 0;
         hid_t                   status;
         struct                  hdf5_args hdf5;
-        daos_prop_t             *prop = NULL;
         daos_cont_layout_t      cont_type;
 
         char **paths = NULL;
@@ -327,7 +326,7 @@ int main(int argc, char** argv)
             mfu_flist_file_set_cont(tmplist, idx, paths[i]);
         }
 
-        tmp_rc = daos_cont_deserialize_connect(daos_args, &hdf5, prop, &cont_type);
+        tmp_rc = daos_cont_deserialize_connect(daos_args, &hdf5, &cont_type);
         if (tmp_rc != 0) {
             MFU_LOG(MFU_LOG_ERR, "failed to connect to container\n");
             rc = 1;


### PR DESCRIPTION
Remove copying of container label when copying from
DAOS->DAOS. The container label in DAOS is now required
to be unique. The container label is still serialized for
now until the API to check if container label already exists
in DAOS is available for use.

Only set container label on deserialization if it does not
exist.

Fix bug in cont_deserialize_all_props where a copy of the
pointer was being passed to it instead of the address to
the pointer, causing the properties to not be set correctly
in cont_create.

Signed-off-by: Danielle Sikich <danielle.sikich@intel.com>