### PR TITLE
daos: cleanup error reporting in serialize and deserialize

### DIFF
--- a/src/daos-deserialize/daos-deserialize.c
+++ b/src/daos-deserialize/daos-deserialize.c
@@ -396,7 +396,7 @@ int main(int argc, char** argv)
     /* Alert the user if there were copy errors */
     if (rc != 0) {
         MFU_LOG(MFU_LOG_ERR, "One or more errors were detected while "
-                "serializing: " MFU_ERRF, MFU_ERRP(MFU_ERR_DAOS));
+                "deserializing: " MFU_ERRF, MFU_ERRP(MFU_ERR_DAOS));
     }
 
     tmp_rc = daos_fini();

--- a/src/daos-serialize/daos-serialize.c
+++ b/src/daos-serialize/daos-serialize.c
@@ -239,7 +239,6 @@ int main(int argc, char** argv)
             rc = 1;
         }
     }
-    MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
 
     /* free newflist that was created for non-posix copy */
     mfu_flist_free(&newflist);
@@ -275,12 +274,15 @@ int main(int argc, char** argv)
         rc = 1;
     }
 
+    int global_rc;
+    MPI_Allreduce(&rc, &global_rc, 1, MPI_INT, MPI_LOR, MPI_COMM_WORLD);
+
     mfu_finalize();
 
     /* shut down MPI */
     MPI_Finalize();
 
-    if (rc != 0) {
+    if (global_rc != 0) {
         return 1;
     }
     return 0;


### PR DESCRIPTION
daos-serialize was using a broadcast to report the rc code
on rank zero, which should be an Allreduce. Also, daos-deserialize
was printing serialize instead of deserialize when reporting an error.

Signed-off-by: Danielle Sikich <danielle.sikich@intel.com>