### PR TITLE
update daos_cont_open_by_label API call

### DIFF
--- a/src/common/mfu_daos.c
+++ b/src/common/mfu_daos.c
@@ -5020,8 +5020,7 @@ int cont_deserialize_all_props(struct hdf5_args *hdf5,
         goto out;
     }
 
-    rc = daos_cont_open_by_label(poh, label_entry->dpe_str, DAOS_COO_RW,
-                                 &coh, &cont_info, NULL);
+    rc = daos_cont_open(poh, label_entry->dpe_str, DAOS_COO_RW, &coh, &cont_info, NULL);
     if (rc == -DER_NONEXIST) {
         /* doesn't exist so ok to deserialize this container label */
         deserialize_label = true;


### PR DESCRIPTION
The daos_cont_open_by_label was removed and is now
using daos_cont_open. Where a UUID or label can be
passed into the function.

Signed-off-by: Danielle Sikich <danielle.sikich@intel.com>