### PR TITLE
dsync and dcp: allow user to control syncing of xattrs

### DIFF
--- a/doc/rst/dcp.1.rst
+++ b/doc/rst/dcp.1.rst
@@ -32,6 +32,16 @@ OPTIONS
    "GB" can immediately follow the number without spaces (e.g. 64MB).
    The default chunksize is 4MB.
 
+.. option:: --xattrs WHICH
+
+    Copy extended attributes ("xattrs") from source files to target files.
+    WHICH determines which xattrs are copied.  Options are to copy no xattrs,
+    all xattrs, xattrs not excluded by /etc/xattr.conf, or all xattrs except
+    those which have special meaning to Lustre.  Certain xattrs control Lustre
+    features on a file-by-file basis, such as how the file data is distributed
+    across Lustre servers.  Values must be in {none, all, libattr, non-lustre}.
+    The default is non-lustre.
+
 .. option:: --daos-api API
 
    Specify the DAOS API to be used. By default, the API is automatically

--- a/doc/rst/dsync.1.rst
+++ b/doc/rst/dsync.1.rst
@@ -39,6 +39,16 @@ OPTIONS
    "GB" can immediately follow the number without spaces (e.g. 64MB).
    The default chunksize is 4MB.
 
+.. option:: --xattrs WHICH
+
+    Copy extended attributes ("xattrs") from source files to target files.
+    WHICH determines which xattrs are copied.  Options are to copy no xattrs,
+    all xattrs, xattrs not excluded by /etc/xattr.conf, or all xattrs except
+    those which have special meaning to Lustre.  Certain xattrs control Lustre
+    features on a file-by-file basis, such as how the file data is distributed
+    across Lustre servers.  Values must be in {none, all, libattr, non-lustre}.
+    The default is non-lustre.
+
 .. option:: --daos-api API
 
    Specify the DAOS API to be used. By default, the API is automatically

--- a/src/common/mfu_param_path.c
+++ b/src/common/mfu_param_path.c
@@ -303,6 +303,31 @@ static void mfu_unpack_param(const char** pptr, mfu_param_path* param)
     return;
 }
 
+/*
+ * Parse an option string provided by the user to determine
+ * which xattrs to copy from source to destination.
+ */
+attr_copy_t parse_copy_xattrs_option(char *optarg)
+{
+    if (strcmp(optarg,"none") == 0) {
+        return XATTR_COPY_NONE;
+    }
+
+    if (strcmp(optarg,"non-lustre") == 0) {
+        return XATTR_SKIP_LUSTRE;
+    }
+
+    if (strcmp(optarg,"libattr") == 0) {
+        return XATTR_USE_LIBATTR;
+    }
+
+    if (strcmp(optarg,"all") == 0) {
+        return XATTR_COPY_ALL;
+    }
+
+    return XATTR_COPY_INVAL;
+}
+
 /**
  * Analyze all file path inputs and place on the work queue.
  *

--- a/src/common/mfu_param_path.h
+++ b/src/common/mfu_param_path.h
@@ -115,25 +115,40 @@ typedef struct {
     int dereference;    /* flag option to dereference symbolic links */
 } mfu_walk_opts_t;
 
+typedef enum {
+    XATTR_COPY_INVAL,
+    XATTR_COPY_NONE,
+    XATTR_SKIP_LUSTRE,
+    XATTR_USE_LIBATTR,
+    XATTR_COPY_ALL,
+} attr_copy_t;
+
 /* options passed to mfu_ */
 typedef struct {
-    int    copy_into_dir;  /* flag indicating whether copying into existing dir */
-    int    do_sync;        /* flag option to sync src dir with dest dir */ 
-    char*  dest_path;      /* prefex of destination directory */
-    char*  input_file;     /* file name of input list */
-    bool   preserve;       /* whether to preserve timestamps, ownership, permissions, etc. */
-    int    dereference;    /* if true, dereference symbolic links in the source.
-                            * this is not a perfect opposite of no_dereference */
-    int    no_dereference; /* if true, don't dereference source symbolic links */
-    bool   direct;         /* whether to use O_DIRECT */
-    bool   sparse;         /* whether to create sparse files */
-    size_t chunk_size;     /* size to chunk files by */
-    size_t buf_size;       /* buffer size to read/write to file system */
-    char*  block_buf1;     /* buffer to read / write data */
-    char*  block_buf2;     /* another buffer to read / write data */
-    int    grouplock_id;   /* Lustre grouplock ID */
-    uint64_t batch_files;  /* max batch size to copy files, 0 implies no limit */
+    int          copy_into_dir;    /* flag indicating whether copying into existing dir */
+    int          do_sync;          /* flag option to sync src dir with dest dir */
+    char*        dest_path;        /* prefex of destination directory */
+    char*        input_file;       /* file name of input list */
+    bool         preserve;         /* whether to preserve timestamps, ownership, permissions, etc. */
+    attr_copy_t  copy_xattrs;      /* which xattrs to copy; important for Lustre */
+    int          dereference;      /* if true, dereference symbolic links in the source.
+                                    * this is not a perfect opposite of no_dereference */
+    int          no_dereference;   /* if true, don't dereference source symbolic links */
+    bool         direct;           /* whether to use O_DIRECT */
+    bool         sparse;           /* whether to create sparse files */
+    size_t       chunk_size;       /* size to chunk files by */
+    size_t       buf_size;         /* buffer size to read/write to file system */
+    char*        block_buf1;       /* buffer to read / write data */
+    char*        block_buf2;       /* another buffer to read / write data */
+    int          grouplock_id;     /* Lustre grouplock ID */
+    uint64_t     batch_files;      /* max batch size to copy files, 0 implies no limit */
 } mfu_copy_opts_t;
+
+/*
+ * Parse an option string provided by the user to determine
+ * which xattrs to copy from source to destination.
+ */
+attr_copy_t parse_copy_xattrs_option(char *optarg);
 
 /* Given a source item name, determine which source path this item
  * is contained within, extract directory components from source

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -144,8 +144,8 @@ int main(int argc, char** argv)
         {"bufsize"              , required_argument, 0, 'b'},
         {"debug"                , required_argument, 0, 'd'}, // undocumented
         {"grouplock"            , required_argument, 0, 'g'}, // untested
-        {"daos-prefix"          , required_argument, 0, 'X'},
-        {"daos-api"             , required_argument, 0, 'x'},
+        {"daos-prefix"          , required_argument, 0, 'Y'},
+        {"daos-api"             , required_argument, 0, 'y'},
         {"daos-preserve"        , required_argument, 0, 'D'},
         {"input"                , required_argument, 0, 'i'},
         {"chunksize"            , required_argument, 0, 'k'},
@@ -240,10 +240,10 @@ int main(int argc, char** argv)
                 break;
 #endif
 #ifdef DAOS_SUPPORT
-            case 'X':
+            case 'Y':
                 daos_args->dfs_prefix = MFU_STRDUP(optarg);
                 break;
-            case 'x':
+            case 'y':
                 if (daos_parse_api_str(optarg, &daos_args->api) != 0) {
                     MFU_LOG(MFU_LOG_ERR, "Failed to parse --daos-api");
                     usage = 1;

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -79,6 +79,7 @@ void print_usage(void)
 #endif
     printf("  -b, --bufsize <SIZE>     - IO buffer size in bytes (default " MFU_BUFFER_SIZE_STR ")\n");
     printf("  -k, --chunksize <SIZE>   - work size per task in bytes (default " MFU_CHUNK_SIZE_STR ")\n");
+    printf("  -X, --xattrs <OPT>       - copy xattrs (none, all, non-lustre, libattr)\n");
 #ifdef DAOS_SUPPORT
     printf("      --daos-api           - DAOS API in {DFS, DAOS} (default uses DFS for POSIX containers)\n");
 #ifdef HDF5_SUPPORT
@@ -89,7 +90,7 @@ void print_usage(void)
     printf("  -i, --input <file>       - read source list from file\n");
     printf("  -L, --dereference        - copy original files instead of links\n");
     printf("  -P, --no-dereference     - don't follow links in source\n");
-    printf("  -p, --preserve           - preserve permissions, ownership, timestamps, extended attributes\n");
+    printf("  -p, --preserve           - preserve permissions, ownership, timestamps (see also --xattrs)\n");
     printf("  -s, --direct             - open files with O_DIRECT\n");
     printf("  -S, --sparse             - create sparse files when possible\n");
     printf("      --progress <N>       - print progress every N seconds\n");
@@ -149,6 +150,7 @@ int main(int argc, char** argv)
         {"daos-preserve"        , required_argument, 0, 'D'},
         {"input"                , required_argument, 0, 'i'},
         {"chunksize"            , required_argument, 0, 'k'},
+        {"xattrs"               , required_argument, 0, 'X'},
         {"dereference"          , no_argument      , 0, 'L'},
         {"no-dereference"       , no_argument      , 0, 'P'},
         {"preserve"             , no_argument      , 0, 'p'},
@@ -167,7 +169,7 @@ int main(int argc, char** argv)
     int usage = 0;
     while(1) {
         int c = getopt_long(
-                    argc, argv, "b:d:g:i:k:LPpsSvqh",
+                    argc, argv, "b:d:g:i:k:LPpsSvqhX:",
                     long_options, &option_index
                 );
 
@@ -228,6 +230,15 @@ int main(int argc, char** argv)
                         MFU_LOG(MFU_LOG_INFO, "Debug level `%s' not recognized. " \
                             "Defaulting to `info'.", optarg);
                     }
+                }
+                break;
+            case 'X':
+                mfu_copy_opts->copy_xattrs = parse_copy_xattrs_option(optarg);
+                if (mfu_copy_opts->copy_xattrs == XATTR_COPY_INVAL) {
+                    if (rank == 0) {
+                        MFU_LOG(MFU_LOG_ERR, "Unrecognized option '%s' for --xattrs", optarg);
+                    }
+                    usage = 1;
                 }
                 break;
 #ifdef LUSTRE_SUPPORT

--- a/src/dsync/dsync.c
+++ b/src/dsync/dsync.c
@@ -3020,8 +3020,8 @@ int main(int argc, char **argv)
         {"batch-files",    1, 0, 'b'},
         {"bufsize",        1, 0, 'B'},
         {"chunksize",      1, 0, 'k'},
-        {"daos-prefix",    1, 0, 'X'},
-        {"daos-api",       1, 0, 'x'},
+        {"daos-prefix",    1, 0, 'Y'},
+        {"daos-api",       1, 0, 'y'},
         {"contents",       0, 0, 'c'},
         {"delete",         0, 0, 'D'},
         {"dereference",    0, 0, 'L'},
@@ -3085,10 +3085,10 @@ int main(int argc, char **argv)
             }
             break;
 #ifdef DAOS_SUPPORT
-        case 'X':
+        case 'Y':
             daos_args->dfs_prefix = MFU_STRDUP(optarg);
             break;
-        case 'x':
+        case 'y':
             if (daos_parse_api_str(optarg, &daos_args->api) != 0) {
                 MFU_LOG(MFU_LOG_ERR, "Failed to parse --daos-api");
                 usage = 1;

--- a/src/dsync/dsync.c
+++ b/src/dsync/dsync.c
@@ -63,6 +63,7 @@ static void print_usage(void)
     printf("  -b  --batch-files <N>   - batch files into groups of N during copy\n");
     printf("      --bufsize <SIZE>    - IO buffer size in bytes (default " MFU_BUFFER_SIZE_STR ")\n");
     printf("      --chunksize <SIZE>  - minimum work size per task in bytes (default " MFU_CHUNK_SIZE_STR ")\n");
+    printf("  -X, --xattrs <OPT>      - copy xattrs (none, all, non-lustre, libattr)\n");
 #ifdef DAOS_SUPPORT
     printf("      --daos-api          - DAOS API in {DFS, DAOS} (default uses DFS for POSIX containers)\n");
 #endif
@@ -3020,6 +3021,7 @@ int main(int argc, char **argv)
         {"batch-files",    1, 0, 'b'},
         {"bufsize",        1, 0, 'B'},
         {"chunksize",      1, 0, 'k'},
+        {"xattrs",         1, 0, 'X'},
         {"daos-prefix",    1, 0, 'Y'},
         {"daos-api",       1, 0, 'y'},
         {"contents",       0, 0, 'c'},
@@ -3050,7 +3052,7 @@ int main(int argc, char **argv)
 
     while (1) {
         int c = getopt_long(
-            argc, argv, "b:cDso:LPSvqh",
+            argc, argv, "b:cDso:LPSvqhX:",
             long_options, &option_index
         );
 
@@ -3082,6 +3084,15 @@ int main(int argc, char **argv)
                 usage = 1;
             } else {
                 copy_opts->chunk_size = bytes;
+            }
+            break;
+        case 'X':
+            copy_opts->copy_xattrs = parse_copy_xattrs_option(optarg);
+            if (copy_opts->copy_xattrs == XATTR_COPY_INVAL) {
+                if (rank == 0) {
+                    MFU_LOG(MFU_LOG_ERR, "Unrecognized option '%s' for --xattrs", optarg);
+                }
+                usage = 1;
             }
             break;
 #ifdef DAOS_SUPPORT

--- a/test/tests/test_dsync/test_xattr.py
+++ b/test/tests/test_dsync/test_xattr.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python2
+import subprocess
+
+# change paths here for bash script as necessary
+mpifu_path     = "~/mpifileutils/test/tests/test_dsync/test_xattr.sh"
+
+# vars in bash script
+dsync_test_bin   = "/root/mpifileutils/install/bin/dsync"
+dsync_src_dir    = "/mnt/lustre"
+dsync_dest_dir   = "/mnt/lustre2"
+dsync_test_file  = "file_test_xattr_XXX"
+
+def test_xattr():
+        p = subprocess.Popen(["%s %s %s %s %s %s %s" % (dsync_test_bin,
+          dsync_src_dir, dsync_dest_dir, dsync_test_file)], shell=True,
+          executable="/bin/bash").communicate()

--- a/test/tests/test_dsync/test_xattr.sh
+++ b/test/tests/test_dsync/test_xattr.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+##############################################################################
+# Description:
+#
+#   A test to check if dsync properly copies xattrs
+#
+##############################################################################
+
+# Turn on verbose output
+#set -x
+
+DSYNC_TEST_BIN=${DSYNC_TEST_BIN:-${1}}
+DSYNC_SRC_DIR=${DSYNC_SRC_DIR:-${2}}
+DSYNC_DEST_DIR=${DSYNC_DEST_DIR:-${3}}
+DSYNC_TMP_FILE=${DSYNC_TMP_FILE:-${4}}
+
+echo "Using dsync binary at: $DSYNC_TEST_BIN"
+echo "Using src directory at: $DSYNC_SRC_DIR"
+echo "Using dest directory at: $DSYNC_DEST_DIR"
+echo "Using temp file name: $DSYNC_TMP_FILE"
+
+set -a lustre_xattr_names
+lustre_xattr_names=("lustre.lov" "trusted.som" "trusted.lov" "trusted.lma" "trusted.lmv" "trusted.dmv" "trusted.link" "trusted.fid" "trusted.version" "trusted.hsm" "trusted.lfsck_bitmap" "trusted.dummy")
+
+set -a other_xattr_names
+other_xattr_names=("xattr1" "456" "testing" "sync_and_verify_test")
+
+function fs_type()
+{
+	fname=$1
+	df -T ${fname} | awk '$1 != "Filesystem" {print $2}'
+}
+
+# set all xattrs in other_xattr_names on file
+# no need for equivalent for lustre xattrs, because they cannot be set from userspace
+function set_other_xattrs()
+{
+	fname=$1
+
+	set -e
+	for attrname in ${other_xattr_names[*]}; do
+		attr -s $attrname -V "$attrname:1234567890" $fname
+	done
+	set +e
+}
+
+function list_all_xattrs()
+{
+	fname=$1
+
+	echo Listing xattrs on $fname
+	attr -l $fname
+}
+
+function compare_xattr_lists()
+{
+	fname0=$1
+	fname1=$2
+
+	for attrname in ${lustre_xattr_names[*]} ${other_xattr_names[*]}; do
+		in0=$(attr -g -q $attrname $fname0 2>/dev/null && echo 1)
+		in1=$(attr -g -q $attrname $fname1 2>/dev/null && echo 1)
+		if [ "$in0" -eq 1 -o "$in1" -eq 1 ]; then
+			echo "$attrname $in0 $in1"
+		fi
+	done
+}
+
+function sync_and_verify()
+{
+	local srcdir=$1
+	local destdir=$2
+	local name=$3
+	local opt=$4
+
+	local result=0
+	local dest_type=$(fs_type $destdir)
+
+	if [ $opt = "non-lustre" ]; then
+		echo "SKIPPED verify of option $opt"
+		return 0
+	fi
+
+	if [ $opt = "libattr" -a $(id -u) -ne 0 ]; then
+		echo "SKIPPED verify of option $opt, need root to test"
+		return 0
+	fi
+
+	set -e
+	rm -f $destdir/$name
+
+	if [ $opt = "libattr" ]; then
+		echo "user.sync_and_verify_test  skip" >> /etc/xattr.conf
+	fi
+
+	$DSYNC_TEST_BIN --quiet --xattrs=$opt $srcdir $destdir
+
+	if [ $opt = "libattr" ]; then
+		sed --in-place "/^user.sync_and_verify_test/d" /etc/xattr.conf
+	fi
+
+	srclog=$(mktemp /tmp/sync_and_verify.src.XXXXX)
+	destlog=$(mktemp /tmp/sync_and_verify.dest.XXXXX)
+
+	list_all_xattrs  $srcdir/$name  | awk '!/Listing xattrs on/ {print $1,$2,$3,$4,$5}'  > $srclog
+	list_all_xattrs  $destdir/$name | awk '!/Listing xattrs on/ {print $1,$2,$3,$4,$5}'  > $destlog
+
+	case $opt in
+	  "none")
+		result=$(wc -c < $destlog)
+		;;
+	  "all")
+		diff $srclog $destlog
+		result=$?
+		;;
+	  "libattr")
+		diff <(grep -v -w sync_and_verify_test $srclog) $destlog
+		result=$?
+		;;
+	esac
+
+	set +e
+
+	if [ "$result" -eq 0 ]; then
+		echo "PASSED verify of option $opt for $destdir type $dest_type"
+	else
+		echo "FAILED verify of option $opt for $destdir type $dest_type"
+		echo =======================
+		echo "dest:"
+		cat $destlog
+		echo =======================
+		exit 1
+	fi
+
+	rm $srclog $destlog
+
+	return $result
+}
+
+# Create the source
+echo Preparing Source
+touch $DSYNC_SRC_DIR/aaa
+set_other_xattrs $DSYNC_SRC_DIR/aaa
+
+# Make sure the short option is accepted; rest of tests use long option
+set -e
+$DSYNC_TEST_BIN --quiet -X all $DSYNC_SRC_DIR $DSYNC_DEST_DIR
+set +e
+
+# Sync and verify
+echo
+echo Testing dsync
+sync_and_verify  $DSYNC_SRC_DIR $DSYNC_DEST_DIR aaa none
+sync_and_verify  $DSYNC_SRC_DIR $DSYNC_DEST_DIR aaa all
+sync_and_verify  $DSYNC_SRC_DIR $DSYNC_DEST_DIR aaa non-lustre
+sync_and_verify  $DSYNC_SRC_DIR $DSYNC_DEST_DIR aaa libattr
+
+# Clean up
+rm $DSYNC_SRC_DIR/aaa
+
+exit 0


### PR DESCRIPTION
Rather than always copying xattrs, introduce a new option
"--xattrs | -e" to allow the user to control how this is done.

Options are
  "none"        Copy no xattrs
  "all"         Copy all xattrs (prior default)
  "non-lustre"  Copy non-lustre xattrs (new default)
  "libattr"        Copy xattrs not indicated as "skip" in /etc/xattr.conf

Copying xattrs is now independent of --preserve for owner, perms,
etc.

Lustre uses xattrs to record important information such as how the file
data should be distributed among the Lustre servers.  As a result,
copying the lustre xattrs prevents certain default values from taking
effect.

If "non-lustre" option is in effect, xattrs named in lustre
source file lustre_idl.h as of this writing are not synced (see
XATTR_NAME_SOM and friends).  In addition, xattrs with prefix
"lustre" are not synced.

Signed-off-by: Olaf Faaland <faaland1@llnl.gov>