### PR TITLE
doc: describe release build

### DIFF
--- a/dist/README.dist
+++ b/dist/README.dist
@@ -19,6 +19,6 @@ For a simple build, one may run the following commands:
     make -j install
 
 For details on available build flags,
-refer to the "Build" section ofi the documentation:
+refer to the "Build" section of the documentation:
 
     https://mpifileutils.readthedocs.io/en/latest/build.html

--- a/doc/rst/conf.py
+++ b/doc/rst/conf.py
@@ -91,19 +91,20 @@ source_encoding = 'utf-8-sig'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-import guzzle_sphinx_theme
+html_theme = 'default'
 
-html_theme_path = guzzle_sphinx_theme.html_theme_path()
-html_theme = 'guzzle_sphinx_theme'
-
-# Register the theme as an extension to generate a sitemap.xml
-extensions.append("guzzle_sphinx_theme")
-
-# Guzzle theme options (see theme.conf for more information)
-html_theme_options = {
-    # Set the name of the project to appear in the sidebar
-    "project_nav_name": "mpiFileUtils",
-}
+#import guzzle_sphinx_theme
+#html_theme_path = guzzle_sphinx_theme.html_theme_path()
+#html_theme = 'guzzle_sphinx_theme'
+#
+## Register the theme as an extension to generate a sitemap.xml
+#extensions.append("guzzle_sphinx_theme")
+#
+## Guzzle theme options (see theme.conf for more information)
+#html_theme_options = {
+#    # Set the name of the project to appear in the sidebar
+#    "project_nav_name": "mpiFileUtils",
+#}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/doc/rst/index.rst
+++ b/doc/rst/index.rst
@@ -3,14 +3,14 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-===================================
-**Documentation for mpiFileUtils**
-===================================
+================
+**mpiFileUtils**
+================
 
 Overview
 *************
 
-mpiFileUtils provides both a library called libmfu and a suite of MPI-based
+mpiFileUtils provides a library named libmfu and a suite of MPI-based
 tools to manage large datasets, which may vary from large directory trees to
 large files. High-performance computing users often generate large datasets with
 parallel applications that run with many processes (millions in some cases).
@@ -28,10 +28,10 @@ User Guide
 .. toctree::
    :maxdepth: 3
 
+   build.rst
    proj-design.rst
    tools.rst
    libmfu.rst
-   build.rst
 
 Man Pages
 ***************************
@@ -54,9 +54,3 @@ Man Pages
    dgrep.1
    dparallel.1
    dtar.1
-
-Indices and tables
-*********************
-
-* :ref:`genindex`
-* :ref:`search`


### PR DESCRIPTION
This updates the build section of the documentation to describe how one builds from the release tarball.  That will simplify the build for most users.  The existing build process that describes how one builds from a clone of the repo is moved to a new development build section.

Signed-off-by: Adam Moody <moody20@llnl.gov>