### PR TITLE
Add O_NOATIME to the flags for file open so the source file's atime i…

### DIFF
--- a/src/common/mfu_io.c
+++ b/src/common/mfu_io.c
@@ -643,6 +643,11 @@ int mfu_open(const char* file, int flags, ...)
         mode_set = 1;
     }
 
+#ifdef _GNU_SOURCE
+    /* Preserve atime on the source file if the platform supports it. */
+    flags |= O_NOATIME;
+#endif
+
     /* attempt to open file */
     int fd = -1;
     errno = 0;


### PR DESCRIPTION
…s preserved (if the platform supports it). Signed-off-by: Doug Johnson <djohnson@osc.edu>.

Lightly tested dsync on Linux (Red Hat 7.9). Not sure if this covers the bases for what's needed to reliably not change the source file's atime. I went off a comment src/common/mfu_flist.h:29 where the _GNU_SOURCE define appears to have been intended to be used for this purpose. I checked the open and closed issues and pull requests to see if this was ever discussed, surprisingly absent. This feature would be useful for those migrating data and that use atime for purging or migration purposes: the source file's atime needs to be preserved in the interregnum between when the copy is initiated, subsequent invocations of `dsync`, and the cutover to the new location of the data is performed.