### PR TITLE
mfu_param_path: fix cutting root component

### DIFF
--- a/src/common/mfu_param_path.c
+++ b/src/common/mfu_param_path.c
@@ -401,13 +401,12 @@ char* mfu_param_path_copy_dest(const char* name, int numpaths,
      * if path is root, keep last component.
      * otherwise cut all components listed in source path */
     int cut = src_components;
-    if (mfu_copy_opts->copy_into_dir && cut > 0) {
-        if (strcmp(paths[i].orig, "/") == 0) {
-            cut--;
-        } else if ((mfu_copy_opts->do_sync != 1) &&
-            (paths[i].orig[strlen(paths[i].orig) - 1] != '/')) {
-            cut--;
-        }
+    if (cut > 0 && strcmp(paths[i].orig, "/") == 0) {
+        cut--;
+    }
+    if ((cut > 0) && mfu_copy_opts->copy_into_dir &&
+            (mfu_copy_opts->do_sync != 1) && (paths[i].orig[strlen(paths[i].orig) - 1] != '/')) {
+        cut--;
     }
 
     /* compute number of components to keep */

--- a/src/common/mfu_param_path.c
+++ b/src/common/mfu_param_path.c
@@ -404,7 +404,7 @@ char* mfu_param_path_copy_dest(const char* name, int numpaths,
     if (cut > 0 && strcmp(paths[i].orig, "/") == 0) {
         cut--;
     }
-    if ((cut > 0) && mfu_copy_opts->copy_into_dir &&
+    else if ((cut > 0) && mfu_copy_opts->copy_into_dir &&
             (mfu_copy_opts->do_sync != 1) && (paths[i].orig[strlen(paths[i].orig) - 1] != '/')) {
         cut--;
     }


### PR DESCRIPTION
Even when `! copy_into_dir`, we still still shouldn't cut the root component.

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>