### PR TITLE
daos: remove --daos-prefix handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ doc/build
 # spack files
 .spack*
 spack.lock
+
+# Code editors
+.vscode

--- a/src/common/mfu_daos.h
+++ b/src/common/mfu_daos.h
@@ -40,7 +40,6 @@ typedef struct {
     char dst_cont[DAOS_PROP_LABEL_MAX_LEN + 1];
     /* if destination container is not created new UUID is generated */
     uuid_t dst_cont_uuid;   /* destination container UUID */
-    char* dfs_prefix;       /* prefix for UNS */
     char* src_path;         /* allocated src path */
     char* dst_path;         /* allocated dst path */
     daos_api_t api;         /* API to use */

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -2118,7 +2118,6 @@ int main(int argc, char **argv)
         {"base",          0, 0, 'b'},
         {"bufsize",       1, 0, 'B'},
         {"chunksize",     1, 0, 'k'},
-        {"daos-prefix",   1, 0, 'X'},
         {"daos-api",      1, 0, 'x'},
         {"direct",        0, 0, 's'},
         {"progress",      1, 0, 'R'},
@@ -2208,9 +2207,6 @@ int main(int argc, char **argv)
             options.debug++;
             break;
 #ifdef DAOS_SUPPORT
-        case 'X':
-            daos_args->dfs_prefix = MFU_STRDUP(optarg);
-            break;
         case 'x':
             if (daos_parse_api_str(optarg, &daos_args->api) != 0) {
                 MFU_LOG(MFU_LOG_ERR, "Failed to parse --daos-api");

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -145,7 +145,6 @@ int main(int argc, char** argv)
         {"bufsize"              , required_argument, 0, 'b'},
         {"debug"                , required_argument, 0, 'd'}, // undocumented
         {"grouplock"            , required_argument, 0, 'g'}, // untested
-        {"daos-prefix"          , required_argument, 0, 'Y'},
         {"daos-api"             , required_argument, 0, 'y'},
         {"daos-preserve"        , required_argument, 0, 'D'},
         {"input"                , required_argument, 0, 'i'},
@@ -251,9 +250,6 @@ int main(int argc, char** argv)
                 break;
 #endif
 #ifdef DAOS_SUPPORT
-            case 'Y':
-                daos_args->dfs_prefix = MFU_STRDUP(optarg);
-                break;
             case 'y':
                 if (daos_parse_api_str(optarg, &daos_args->api) != 0) {
                     MFU_LOG(MFU_LOG_ERR, "Failed to parse --daos-api");

--- a/src/dsync/dsync.c
+++ b/src/dsync/dsync.c
@@ -3022,7 +3022,6 @@ int main(int argc, char **argv)
         {"bufsize",        1, 0, 'B'},
         {"chunksize",      1, 0, 'k'},
         {"xattrs",         1, 0, 'X'},
-        {"daos-prefix",    1, 0, 'Y'},
         {"daos-api",       1, 0, 'y'},
         {"contents",       0, 0, 'c'},
         {"delete",         0, 0, 'D'},
@@ -3096,9 +3095,6 @@ int main(int argc, char **argv)
             }
             break;
 #ifdef DAOS_SUPPORT
-        case 'Y':
-            daos_args->dfs_prefix = MFU_STRDUP(optarg);
-            break;
         case 'y':
             if (daos_parse_api_str(optarg, &daos_args->api) != 0) {
                 MFU_LOG(MFU_LOG_ERR, "Failed to parse --daos-api");


### PR DESCRIPTION
This was previously deprecated and is longer needed. The new way is to use a UNS path:
daos://pool/container/path/to/stuff

Signed-off-by: Dalton Bohning <dalton.bohning@intel.com>