### PR TITLE
ddup: print file size warning with trailing newline

### DIFF
--- a/src/ddup/ddup.c
+++ b/src/ddup/ddup.c
@@ -394,9 +394,7 @@ int main(int argc, char** argv)
                                chunk_size, file_size, &data_size);
             if (status) {
                 /* File size has been changed, TODO: handle */
-                printf("failed to read file %s, maybe file "
-                       "size has been modified during the "
-                       "process", fname);
+                MFU_LOG(MFU_LOG_WARN, "Failed to read %s, size may have changed", fname);
             }
 
             /* update the SHA256 context for this file */


### PR DESCRIPTION
Resolves: https://github.com/hpc/mpifileutils/issues/556