### PR TITLE
mfu: add --open-noatime to open files with O_NOATIME

### DIFF
--- a/doc/rst/dcmp.1.rst
+++ b/doc/rst/dcmp.1.rst
@@ -60,6 +60,10 @@ OPTIONS
 
    Use O_DIRECT to avoid caching file data.
 
+.. option:: --open-noatime
+
+   Open files with O_NOATIME flag.
+
 .. option:: --progress N
 
    Print progress message to stdout approximately every N seconds.

--- a/doc/rst/dcp.1.rst
+++ b/doc/rst/dcp.1.rst
@@ -82,6 +82,10 @@ OPTIONS
 
    Use O_DIRECT to avoid caching file data.
 
+.. option:: --open-noatime
+
+   Open files with O_NOATIME flag.
+
 .. option:: -S, --sparse
 
    Create sparse files when possible.

--- a/doc/rst/ddup.1.rst
+++ b/doc/rst/ddup.1.rst
@@ -20,6 +20,10 @@ Multiple sets of duplicate files can be matched using this final reported hash.
 OPTIONS
 -------
 
+.. option:: --open-noatime
+
+   Open files with O_NOATIME flag, if possible.
+
 .. option:: -d, --debug LEVEL
 
    Set verbosity level.  LEVEL can be one of: fatal, err, warn, info, dbg.

--- a/doc/rst/dsync.1.rst
+++ b/doc/rst/dsync.1.rst
@@ -83,6 +83,10 @@ OPTIONS
 
    Use O_DIRECT to avoid caching file data.
 
+.. option:: --open-noatime
+
+   Open files with O_NOATIME flag.
+
 .. option:: --link-dest DIR
 
    Create hardlink in DEST to files in DIR when file is unchanged

--- a/doc/rst/dtar.1.rst
+++ b/doc/rst/dtar.1.rst
@@ -119,6 +119,10 @@ OPTIONS
    Apply recorded flags to extracted files.
    Default does not record or extract flags.
 
+.. option:: --open-noatime
+
+   Open source files with O_NOATIME flag when creating archive.
+
 .. option:: --fsync
 
    Call fsync before closing files after writing.

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -15,6 +15,7 @@ LIST(APPEND libmfu_install_headers
   mfu_param_path.h
   mfu_path.h
   mfu_pred.h
+  mfu_proc.h
   mfu_progress.h
   mfu_util.h
   )
@@ -46,6 +47,7 @@ LIST(APPEND libmfu_srcs
   mfu_param_path.c
   mfu_path.c
   mfu_pred.c
+  mfu_proc.c
   mfu_progress.c
   mfu_util.c
   strmap.c

--- a/src/common/mfu.h
+++ b/src/common/mfu.h
@@ -27,6 +27,7 @@ extern "C" {
 #include "mfu_param_path.h"
 #include "mfu_flist.h"
 #include "mfu_pred.h"
+#include "mfu_proc.h"
 #include "mfu_progress.h"
 #include "mfu_bz2.h"
 

--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -633,6 +633,7 @@ typedef struct {
     bool    preserve_acls;
     bool    preserve_fflags;
     bool    preserve;
+    bool    open_noatime;
     int     flags;
     size_t  chunk_size;
     size_t  buf_size;

--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -178,6 +178,9 @@ static int mfu_copy_open_file(
     /* open the new file, this sets mfu_file->fd/obj */
     if (read_flag) {
         int flags = O_RDONLY;
+        if (copy_opts->open_noatime) {
+            flags |= O_NOATIME;
+        }
         if (copy_opts->direct) {
             flags |= O_DIRECT;
         }
@@ -3337,6 +3340,9 @@ mfu_copy_opts_t* mfu_copy_opts_new(void)
 
     /* By default, don't use O_DIRECT. */
     opts->direct = false;
+
+    /* By default, don't use O_NOATIME. */
+    opts->open_noatime = false;
 
     /* By default, don't use sparse file. */
     opts->sparse = false;

--- a/src/common/mfu_param_path.h
+++ b/src/common/mfu_param_path.h
@@ -135,6 +135,7 @@ typedef struct {
                                     * this is not a perfect opposite of no_dereference */
     int          no_dereference;   /* if true, don't dereference source symbolic links */
     bool         direct;           /* whether to use O_DIRECT */
+    bool         open_noatime;     /* whether to use O_NOATIME */
     bool         sparse;           /* whether to create sparse files */
     size_t       chunk_size;       /* size to chunk files by */
     size_t       buf_size;         /* buffer size to read/write to file system */

--- a/src/common/mfu_proc.c
+++ b/src/common/mfu_proc.c
@@ -1,0 +1,55 @@
+/* Defines a double linked list representing a file path. */
+
+#include "mfu.h"
+
+#include <unistd.h>
+
+#include <errno.h>
+#include <string.h>
+
+#ifdef HAVE_LIBCAP
+#include <sys/capability.h>
+#endif
+
+/* query properties and capabilities of current process */
+void mfu_proc_set(mfu_proc_t* proc)
+{
+    proc->getuid  = getuid();
+    proc->geteuid = geteuid();
+
+    proc->cap_chown  = false;
+    proc->cap_fowner = false;
+
+#ifdef HAVE_LIBCAP
+    /* query current process capability settings */
+    cap_t caps = cap_get_proc();
+    if (caps != NULL) {
+        int rc;
+        cap_flag_value_t flag;
+
+        /* check for CAP_CHOWN */
+        rc = cap_get_flag(caps, CAP_CHOWN, CAP_EFFECTIVE, &flag);
+        if (rc == 0) {
+            proc->cap_chown = (flag == CAP_SET);
+        } else {
+            MFU_LOG(MFU_LOG_ERR, "cap_get_flag(CAP_CHOWN) failed: errno=%d (%s)", errno, strerror(errno));
+        }
+
+        /* check for CAP_FOWNER */
+        rc = cap_get_flag(caps, CAP_FOWNER, CAP_EFFECTIVE, &flag);
+        if (rc == 0) {
+            proc->cap_fowner = (flag == CAP_SET);
+        } else {
+            MFU_LOG(MFU_LOG_ERR, "cap_get_flag(CAP_FOWNER) failed: errno=%d (%s)", errno, strerror(errno));
+        }
+
+        /* free capabilities structure */
+        rc = cap_free(caps);
+        if (rc == -1) {
+            MFU_LOG(MFU_LOG_ERR, "cap_free() failed: errno=%d (%s)", errno, strerror(errno));
+        }
+    } else {
+        MFU_LOG(MFU_LOG_ERR, "cap_get_proc() failed: errno=%d (%s)", errno, strerror(errno));
+    }
+#endif
+}

--- a/src/common/mfu_proc.h
+++ b/src/common/mfu_proc.h
@@ -1,0 +1,18 @@
+#ifndef MFU_PROC_H
+#define MFU_PROC_H
+
+#include <unistd.h>
+#include <sys/types.h>
+
+/* records properties about the current process */
+typedef struct mfu_proc_struct {
+  uid_t getuid;
+  uid_t geteuid;
+  bool cap_chown;
+  bool cap_fowner;
+} mfu_proc_t;
+
+/* query and cache values for current process */
+void mfu_proc_set(mfu_proc_t* proc);
+
+#endif /* MFU_PROC_H */

--- a/src/common/mfu_util.c
+++ b/src/common/mfu_util.c
@@ -725,6 +725,7 @@ int mfu_compare_contents(
     /* extract values from copy options */
     int direct = copy_opts->direct;
     size_t buf_size = copy_opts->buf_size;
+    bool noatime = copy_opts->open_noatime;
 
     /* for O_DIRECT, check that length is a multiple of buf_size */
     if (direct &&                      /* using O_DIRECT */
@@ -737,6 +738,9 @@ int mfu_compare_contents(
 
     /* open source as read only, with optional O_DIRECT */
     int src_flags = O_RDONLY;
+    if (noatime) {
+        src_flags |= O_NOATIME;
+    }
     if (direct) {
         src_flags |= O_DIRECT;
     }
@@ -755,6 +759,9 @@ int mfu_compare_contents(
     int dst_flags = O_RDONLY;
     if (overwrite) {
         dst_flags = O_RDWR;
+    }
+    if (noatime) {
+        dst_flags |= O_NOATIME;
     }
     if (direct) {
         dst_flags |= O_DIRECT;

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -45,6 +45,7 @@ static void print_usage(void)
     printf("      --daos-api            - DAOS API in {DFS, DAOS} (default uses DFS for POSIX containers)\n");
 #endif
     printf("  -s, --direct              - open files with O_DIRECT\n");
+    printf("      --open-noatime        - open files with O_NOATIME\n");
     printf("      --progress <N>        - print progress every N seconds\n");
     printf("  -v, --verbose             - verbose output\n");
     printf("  -q, --quiet               - quiet output\n");
@@ -2120,6 +2121,7 @@ int main(int argc, char **argv)
         {"chunksize",     1, 0, 'k'},
         {"daos-api",      1, 0, 'x'},
         {"direct",        0, 0, 's'},
+        {"open-noatime",  0, 0, 'U'},
         {"progress",      1, 0, 'R'},
         {"verbose",       0, 0, 'v'},
         {"quiet",         0, 0, 'q'},
@@ -2184,6 +2186,12 @@ int main(int argc, char **argv)
             copy_opts->direct = true;
             if(rank == 0) {
                 MFU_LOG(MFU_LOG_INFO, "Using O_DIRECT");
+            }
+            break;
+        case 'U':
+            copy_opts->open_noatime = true;
+            if(rank == 0) {
+                MFU_LOG(MFU_LOG_INFO, "Using O_NOATIME");
             }
             break;
         case 'R':

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -92,6 +92,7 @@ void print_usage(void)
     printf("  -P, --no-dereference     - don't follow links in source\n");
     printf("  -p, --preserve           - preserve permissions, ownership, timestamps (see also --xattrs)\n");
     printf("  -s, --direct             - open files with O_DIRECT\n");
+    printf("      --open-noatime       - open files with O_NOATIME\n");
     printf("  -S, --sparse             - create sparse files when possible\n");
     printf("      --progress <N>       - print progress every N seconds\n");
     printf("  -G  --gid <GID>          - Set the group id to perform copy\n");
@@ -160,6 +161,7 @@ int main(int argc, char** argv)
         {"preserve"             , no_argument      , 0, 'p'},
         {"synchronous"          , no_argument      , 0, 's'},
         {"direct"               , no_argument      , 0, 's'},
+        {"open-noatime"         , no_argument      , 0, 'A'},
         {"sparse"               , no_argument      , 0, 'S'},
         {"progress"             , required_argument, 0, 'R'},
         {"gid"                  , required_argument, 0, 'G'},
@@ -312,6 +314,12 @@ int main(int argc, char** argv)
                 mfu_copy_opts->direct = 1;
                 if(rank == 0) {
                     MFU_LOG(MFU_LOG_INFO, "Using O_DIRECT");
+                }
+                break;
+            case 'A':
+                mfu_copy_opts->open_noatime = true;
+                if(rank == 0) {
+                    MFU_LOG(MFU_LOG_INFO, "Using O_NOATIME");
                 }
                 break;
             case 'S':

--- a/src/dsync/dsync.c
+++ b/src/dsync/dsync.c
@@ -72,6 +72,7 @@ static void print_usage(void)
     printf("  -L, --dereference       - copy original files instead of links\n");
     printf("  -P, --no-dereference    - don't follow links in source\n"); 
     printf("  -s, --direct            - open files with O_DIRECT\n");
+    printf("      --open-noatime      - open files with O_NOATIME\n");
     printf("      --link-dest <DIR>   - hardlink to files in DIR when unchanged\n");
     printf("  -S, --sparse            - create sparse files when possible\n");
     printf("      --progress <N>      - print progress every N seconds\n");
@@ -3028,6 +3029,7 @@ int main(int argc, char **argv)
         {"dereference",    0, 0, 'L'},
         {"no-dereference", 0, 0, 'P'},
         {"direct",         0, 0, 's'},
+        {"open-noatime",   0, 0, 'U'},
         {"output",         1, 0, 'o'}, // undocumented
         {"debug",          0, 0, 'd'}, // undocumented
         {"link-dest",      1, 0, 'l'},
@@ -3128,6 +3130,12 @@ int main(int argc, char **argv)
             copy_opts->direct = true;
             if(rank == 0) {
                 MFU_LOG(MFU_LOG_INFO, "Using O_DIRECT");
+            }
+            break;
+        case 'U':
+            copy_opts->open_noatime = true;
+            if(rank == 0) {
+                MFU_LOG(MFU_LOG_INFO, "Using O_NOATIME");
             }
             break;
         case 'l':

--- a/src/dtar/dtar.c
+++ b/src/dtar/dtar.c
@@ -145,6 +145,7 @@ static void print_usage(void)
 //    printf("      --preserve-acls     - preserve acls (default ignores acls)\n");
 //    printf("      --preserve-flags    - preserve fflags (default ignores ioctl iflags)\n");
     printf("      --fsync             - sync file data to disk on close\n");
+    printf("      --open-noatime      - open source files with O_NOATIME\n");
     printf("  -b, --bufsize <SIZE>    - IO buffer size in bytes (default " MFU_BUFFER_SIZE_STR ")\n");
     printf("  -k, --chunksize <SIZE>  - work size per task in bytes (default " MFU_CHUNK_SIZE_STR ")\n");
     printf("      --memsize <SIZE>    - memory limit per task for parallel read in bytes (default 256MB)\n");
@@ -200,6 +201,7 @@ int main(int argc, char** argv)
         {"preserve-acls",   0, 0, 'A'},
         {"preserve-flags",  0, 0, 'F'},
         {"fsync",     0, 0, 's'},
+        {"open-noatime",    0, 0, 'U'},
         {"bufsize",   1, 0, 'b'},
         {"chunksize", 1, 0, 'k'},
         {"memsize",   1, 0, 'm'},
@@ -263,6 +265,9 @@ int main(int argc, char** argv)
                 break;
             case 's':
                 archive_opts->sync_on_close = true;
+                break;
+            case 'U':
+                archive_opts->open_noatime = true;
                 break;
             case 'b':
                 if (mfu_abtoull(optarg, &bytes) != MFU_SUCCESS || bytes == 0) {


### PR DESCRIPTION
This adds an ``--open-noatime`` option to a number of tools, which adds the ``O_NOATIME`` flag when opening files to avoid updating the file last access time.

Many centers use last access time to filter files for purge operations, and they would prefer not to change file atime values when making backup copies with ``dsync`` or scanning the file system for duplicate files with ``ddup``.  Adding this flag may also improve read performance on some file systems.

The ``O_NOATIME`` flag is only allowed when the effective user id matches the owner of the file or when the process is running with the ``CAP_FOWNER`` capability.  A normal user will encounter errors when using ``O_NOATIME`` when reading from a shared directory containing files owned by other users, even if the current user has read access to all files.

The following tools are affected:

``ddup`` - when reading files to compute hash values
``dcp`` and ``dsync`` - when reading source files during a copy
``dcmp`` and ``dsync`` - when reading source and destination files while comparing their contents
``dtar`` - while reading source files when creating an archive

Wheen ``--open-noatime`` is specified with ``ddup``, the tool checks the owner user id of each file and conditionally adds ``O_NOATIME`` if the process effective user id matches.  This allows normal users to specify the ``--open-noatime`` option, even when running ``ddup`` on files that they don't own.  The atime will be updated on files that the user can read but does not own.

For the remaining tools, the current algorithms do not expose the file owner id in a way to allow for an easy check.  In this case, ``O_NOATIME`` is added when opening *all* files.  Normal users will thus encounter an error if the tool attempts to open any file that they do not own.

Resolves:
https://github.com/hpc/mpifileutils/issues/557
https://github.com/hpc/mpifileutils/pull/534