### PR TITLE
MFU-578: add xattr.h header to mfu_io.c

### DIFF
--- a/src/common/mfu_io.c
+++ b/src/common/mfu_io.c
@@ -2,6 +2,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/xattr.h>
 #include <unistd.h>
 
 #include <fcntl.h>


### PR DESCRIPTION
include the xattr.h header in mfu_io.c to avoid compilation errors (ISO C99 and later do not support implicit function declarations)