### PR TITLE
Add option to not update the file last access time with dwalk

### DIFF
--- a/doc/rst/dwalk.1.rst
+++ b/doc/rst/dwalk.1.rst
@@ -70,6 +70,10 @@ OPTIONS
 
    Print files to the screen.
 
+.. option:: -n, --no-atime
+
+   Must bu used with --lite option. Do not update last file access time.
+
 .. option:: -L, --dereference
 
    Dereference symbolic links and walk the target file or directory

--- a/man/dwalk.1
+++ b/man/dwalk.1
@@ -103,6 +103,11 @@ Print files to the screen.
 .UNINDENT
 .INDENT 0.0
 .TP
+.B \-n, \-\-no\-atime
+Must be used with the \-\-lite option. Do not update the file last access time.
+.UNINDENT
+.INDENT 0.0
+.TP
 .B \-L, \-\-dereference
 Dereference symbolic links and walk the target file or directory
 that each symbolic link refers to.

--- a/src/common/mfu_flist.c
+++ b/src/common/mfu_flist.c
@@ -67,6 +67,9 @@ mfu_walk_opts_t* mfu_walk_opts_new(void)
     /* Don't dereference symbolic links by default */
     opts->dereference = 0;
 
+    /* Don't update the file last access time */
+    opts->no_atime = 0;
+
     return opts;
 }
 

--- a/src/common/mfu_param_path.h
+++ b/src/common/mfu_param_path.h
@@ -113,6 +113,7 @@ typedef struct {
     int remove;         /* flag option to remove files during walk */
     int use_stat;       /* flag option on whether or not to stat files during walk */
     int dereference;    /* flag option to dereference symbolic links */
+    int no_atime;       /* flag option to not update the file last acess time */
 } mfu_walk_opts_t;
 
 typedef enum {

--- a/src/dwalk/dwalk.c
+++ b/src/dwalk/dwalk.c
@@ -319,6 +319,7 @@ static void print_usage(void)
     printf("  -d, --distribution <field>:<separators> \n                          - print distribution by field\n");
     printf("  -f, --file_histogram    - print default size distribution of items\n");
     printf("  -p, --print             - print files to screen\n");
+    printf("  -n, --no-atime          - use with -l; do not update the file last access time\n");
     printf("  -L, --dereference       - follow symbolic links\n");
     printf("      --progress <N>      - print progress every N seconds\n");
     printf("  -v, --verbose           - verbose output\n");
@@ -390,6 +391,7 @@ int main(int argc, char** argv)
         {"distribution",   1, 0, 'd'},
         {"file_histogram", 0, 0, 'f'},
         {"print",          0, 0, 'p'},
+        {"no-atime",       0, 0, 'n'},
         {"dereference",    0, 0, 'L'},
         {"progress",       1, 0, 'R'},
         {"verbose",        0, 0, 'v'},
@@ -401,7 +403,7 @@ int main(int argc, char** argv)
     int usage = 0;
     while (1) {
         int c = getopt_long(
-                    argc, argv, "i:o:tls:d:fpLvqh",
+                    argc, argv, "i:o:tls:d:fpLvqhn",
                     long_options, &option_index
                 );
 
@@ -431,6 +433,9 @@ int main(int argc, char** argv)
                 break;
             case 'p':
                 print = 1;
+                break;
+            case 'n':
+                walk_opts->no_atime = 1;
                 break;
             case 'L':
                 walk_opts->dereference = 1;


### PR DESCRIPTION
This is a proposal to add -n, --no-atime option on dwalk to not update the file last access time while doing a walk without stat.

The motivation behind this patch is that at CEA we have tools to administrate our filesystems and we want to use mpifileutils in these tools. We don't want the atime of a folder to be modified when admins walk a filesystem. For us, updating the atime is a user-side action and should therefore not be modified by our tools.

