### PR TITLE
build.rst shell script: stop if dependency download fails

### DIFF
--- a/doc/rst/build.rst
+++ b/doc/rst/build.rst
@@ -133,34 +133,51 @@ which can be done with the following commands:
 
    mkdir deps
    cd deps
-     wget https://github.com/hpc/libcircle/releases/download/v0.3/libcircle-0.3.0.tar.gz
-     wget https://github.com/llnl/lwgrp/releases/download/v1.0.4/lwgrp-1.0.4.tar.gz
-     wget https://github.com/llnl/dtcmp/releases/download/v1.1.4/dtcmp-1.1.4.tar.gz
-     wget https://github.com/libarchive/libarchive/releases/download/v3.5.1/libarchive-3.5.1.tar.gz
 
-     tar -zxf libcircle-0.3.0.tar.gz
-     cd libcircle-0.3.0
-       ./configure --prefix=$installdir
-       make install
-     cd ..
+     urls=(     https://github.com/hpc/libcircle/releases/download/v0.3/libcircle-0.3.0.tar.gz
+                https://github.com/llnl/lwgrp/releases/download/v1.0.4/lwgrp-1.0.4.tar.gz
+                https://github.com/llnl/dtcmp/releases/download/v1.1.4/dtcmp-1.1.4.tar.gz
+                https://github.com/libarchive/libarchive/releases/download/3.5.1/libarchive-3.5.1.tar.gz
+     )
 
-     tar -zxf lwgrp-1.0.4.tar.gz
-     cd lwgrp-1.0.4
-       ./configure --prefix=$installdir
-       make install
-     cd ..
+     rc=0
+     for url in ${urls[*]}; do
+         if [[ rc -eq 0 ]]; then
+             wget $url
+             rc=$?
+             if [[ $rc -ne 0 ]]; then
+                 echo
+                 echo FAILED getting $url
+                 echo check for releases under $(echo $url | sed 's/releases.*/releases\//')
+             fi
+         fi
+     done
 
-     tar -zxf dtcmp-1.1.4.tar.gz
-     cd dtcmp-1.1.4
-       ./configure --prefix=$installdir --with-lwgrp=$installdir
-       make install
-     cd ..
+     if [[ rc -eq 0 ]]; then
+         tar -zxf libcircle-0.3.0.tar.gz
+         cd libcircle-0.3.0
+           ./configure --prefix=$installdir
+           make install
+         cd ..
 
-     tar -zxf libarchive-3.5.1.tar.gz
-     cd libarchive-3.5.1
-       ./configure --prefix=$installdir
-       make install
-     cd ..
+         tar -zxf lwgrp-1.0.4.tar.gz
+         cd lwgrp-1.0.4
+           ./configure --prefix=$installdir
+           make install
+         cd ..
+
+         tar -zxf dtcmp-1.1.4.tar.gz
+         cd dtcmp-1.1.4
+           ./configure --prefix=$installdir --with-lwgrp=$installdir
+           make install
+         cd ..
+
+         tar -zxf libarchive-3.5.1.tar.gz
+         cd libarchive-3.5.1
+           ./configure --prefix=$installdir
+           make install
+         cd ..
+       fi
    cd ..
 
 One can then clone, build, and install mpiFileUtils:


### PR DESCRIPTION
The developer build instructions include some shell scripting to download, build, and install dependencies (e.g. libcircle, lwgrp).  That scripting assumes paths to dependency release tarballs that may be out-of-date.

If a dependency tarball download fails, tell the user which one failed and where to look, and do not proceed to building and installing.

After a release these docs may quickly become out-of-date, and so it can save some developer time to fail faster and give a clearer error message.