### PR TITLE
fixes to test_dsync/test_xattr.sh and test_dsync/test_xattr.py

### DIFF
--- a/test/tests/test_dsync/test_xattr.py
+++ b/test/tests/test_dsync/test_xattr.py
@@ -11,6 +11,6 @@ dsync_dest_dir   = "/mnt/lustre2"
 dsync_test_file  = "file_test_xattr_XXX"
 
 def test_xattr():
-        p = subprocess.Popen(["%s %s %s %s %s %s %s" % (dsync_test_bin,
+        p = subprocess.Popen(["%s %s %s %s %s" % (mpifu_path, dsync_test_bin,
           dsync_src_dir, dsync_dest_dir, dsync_test_file)], shell=True,
           executable="/bin/bash").communicate()

--- a/test/tests/test_dsync/test_xattr.sh
+++ b/test/tests/test_dsync/test_xattr.sh
@@ -94,7 +94,14 @@ function sync_and_verify()
 		echo "user.sync_and_verify_test  skip" >> /etc/xattr.conf
 	fi
 
-	$DSYNC_TEST_BIN --quiet --xattrs=$opt $srcdir $destdir
+
+	if [[ $opt = "no-xattr-option" ]]; then
+		xattropt=""
+	else
+		xattropt="--xattrs=$opt"
+	fi
+
+	$DSYNC_TEST_BIN --quiet $xattropt $srcdir $destdir
 
 	if [ $opt = "libattr" ]; then
 		sed --in-place "/^user.sync_and_verify_test/d" /etc/xattr.conf
@@ -151,6 +158,7 @@ set +e
 # Sync and verify
 echo
 echo Testing dsync
+sync_and_verify  $DSYNC_SRC_DIR $DSYNC_DEST_DIR aaa no-xattr-option
 sync_and_verify  $DSYNC_SRC_DIR $DSYNC_DEST_DIR aaa none
 sync_and_verify  $DSYNC_SRC_DIR $DSYNC_DEST_DIR aaa all
 sync_and_verify  $DSYNC_SRC_DIR $DSYNC_DEST_DIR aaa non-lustre

--- a/test/tests/test_dsync/test_xattr.sh
+++ b/test/tests/test_dsync/test_xattr.sh
@@ -50,7 +50,7 @@ function list_all_xattrs()
 	fname=$1
 
 	echo Listing xattrs on $fname
-	attr -l $fname
+	attr -l $fname | sort
 }
 
 function compare_xattr_lists()


### PR DESCRIPTION
Fixes two issues:
1. The command line generated in test_xattr.py to execute test_xattr.sh and run the test was wrong.  Fix that.
2. The output of "xattr -l" needs to be sorted for the xattr comparison to work consistently

Tested on lustre and xfs