### PR TITLE
dsync: disable --delete on src walk error

### DIFF
--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -180,7 +180,7 @@ void mfu_flist_free(mfu_flist* flist);
  * optionally stat each item, and optionally
  * set directory permission bits in order to walk into a directory,
  * whose permission bits are otherwise restrictive (e.g., useful for recursive unlink) */
-void mfu_flist_walk_path(
+int mfu_flist_walk_path(
     const char* path,           /* IN  - path to be walked */
     mfu_walk_opts_t* walk_opts, /* IN  - functions to perform during the walk */
     mfu_flist flist,            /* OUT - flist to insert walked items into */
@@ -188,7 +188,7 @@ void mfu_flist_walk_path(
 );
 
 /* create file list by walking list of directories */
-void mfu_flist_walk_paths(
+int mfu_flist_walk_paths(
     uint64_t num_paths,         /* IN  - number of paths in array */
     const char** paths,         /* IN  - array of paths to be walkted */
     mfu_walk_opts_t* walk_opts, /* IN  - functions to perform during the walk */
@@ -197,7 +197,7 @@ void mfu_flist_walk_paths(
 );
 
 /* given a list of param_paths, walk each one and add to flist */
-void mfu_flist_walk_param_paths(
+int mfu_flist_walk_param_paths(
     uint64_t num,                 /* IN  - number of paths in array */
     const mfu_param_path* params, /* IN  - array of paths to be walkted */
     mfu_walk_opts_t* walk_opts,   /* IN  - functions to perform during the walk */

--- a/src/common/mfu_flist_walk.c
+++ b/src/common/mfu_flist_walk.c
@@ -51,6 +51,7 @@ static flist_t* CURRENT_LIST;
 static int SET_DIR_PERMS;
 static int REMOVE_FILES;
 static int DEREFERENCE;
+static int WALK_RESULT = 0;
 static mfu_file_t** CURRENT_PFILE;
 
 /****************************************
@@ -116,6 +117,7 @@ static int build_path(char* path, size_t path_len, const char* dir, const char* 
     if (new_len > path_len) {
         MFU_LOG(MFU_LOG_ERR, "Path name is too long, %lu chars exceeds limit %lu: '%s/%s'",
                 new_len, path_len, dir, name);
+        WALK_RESULT = errno;
         return -1;
     }
 
@@ -188,6 +190,7 @@ static void walk_getdents_process_dir(const char* dir, CIRCLE_handle* handle)
     if (mfu_file->fd == -1) {
         /* print error */
         MFU_LOG(MFU_LOG_ERR, "Failed to open directory for reading: `%s' (errno=%d %s)", dir, errno, strerror(errno));
+        WALK_RESULT = errno;
         return;
     }
 
@@ -200,6 +203,7 @@ static void walk_getdents_process_dir(const char* dir, CIRCLE_handle* handle)
         int nread = syscall(SYS_getdents, mfu_file->fd, buf, (int) BUF_SIZE);
         if (nread == -1) {
             MFU_LOG(MFU_LOG_ERR, "syscall to getdents failed when reading `%s' (errno=%d %s)", dir, errno, strerror(errno));
+            WALK_RESULT = errno;
             break;
         }
 
@@ -289,6 +293,7 @@ static void walk_getdents_create(CIRCLE_handle* handle)
         if (status != 0) {
             MFU_LOG(MFU_LOG_ERR, "Failed to stat: '%s' (errno=%d %s)",
                     path, errno, strerror(errno));
+            WALK_RESULT = errno;
             return;
         }
 
@@ -347,6 +352,7 @@ static void walk_readdir_process_dir(const char* dir, CIRCLE_handle* handle)
     if (! dirp) {
         MFU_LOG(MFU_LOG_ERR, "Failed to open directory with opendir: '%s' (errno=%d %s)",
                 dir, errno, strerror(errno));
+        WALK_RESULT = errno;
     }
     else {
         /* Read all directory entries */
@@ -398,6 +404,7 @@ static void walk_readdir_process_dir(const char* dir, CIRCLE_handle* handle)
                         else {
                             MFU_LOG(MFU_LOG_ERR, "Failed to stat: '%s' (errno=%d %s)",
                                     newpath, errno, strerror(errno));
+                            WALK_RESULT = errno;
                         }
                     }
 
@@ -433,6 +440,7 @@ static void walk_readdir_create(CIRCLE_handle* handle)
         if (status != 0) {
             MFU_LOG(MFU_LOG_ERR, "Failed to stat: '%s' (errno=%d %s)",
                     path, errno, strerror(errno));
+            WALK_RESULT = errno;
             return;
         }
 
@@ -475,6 +483,7 @@ static void walk_stat_process_dir(char* dir, CIRCLE_handle* handle)
     if (! dirp) {
         MFU_LOG(MFU_LOG_ERR, "Failed to open directory with opendir: '%s' (errno=%d %s)",
                 dir, errno, strerror(errno));
+        WALK_RESULT = errno;
     }
     else {
         while (1) {
@@ -533,6 +542,7 @@ static void walk_stat_process(CIRCLE_handle* handle)
     if (status != 0) {
         MFU_LOG(MFU_LOG_ERR, "Failed to stat: '%s' (errno=%d %s)",
                 path, errno, strerror(errno));
+        WALK_RESULT = errno;
         return;
     }
 
@@ -570,17 +580,16 @@ static void walk_stat_process(CIRCLE_handle* handle)
 }
 
 /* Set up and execute directory walk */
-void mfu_flist_walk_path(const char* dirpath,
+int mfu_flist_walk_path(const char* dirpath,
                          mfu_walk_opts_t* walk_opts,
                          mfu_flist bflist,
                          mfu_file_t* mfu_file)
 {
-    mfu_flist_walk_paths(1, &dirpath, walk_opts, bflist, mfu_file);
-    return;
+    return mfu_flist_walk_paths(1, &dirpath, walk_opts, bflist, mfu_file);
 }
 
 /* Set up and execute directory walk */
-void mfu_flist_walk_paths(uint64_t num_paths, const char** paths,
+int mfu_flist_walk_paths(uint64_t num_paths, const char** paths,
                           mfu_walk_opts_t* walk_opts, mfu_flist bflist,
                           mfu_file_t* mfu_file)
 {
@@ -703,11 +712,14 @@ void mfu_flist_walk_paths(uint64_t num_paths, const char** paths,
     /* hold procs here until summary is printed */
     MPI_Barrier(MPI_COMM_WORLD);
 
-    return;
+    int all_rc;
+    MPI_Allreduce(&WALK_RESULT, &all_rc, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+
+    return all_rc;
 }
 
 /* given a list of param_paths, walk each one and add to flist */
-void mfu_flist_walk_param_paths(uint64_t num,
+int mfu_flist_walk_param_paths(uint64_t num,
                                 const mfu_param_path* params,
                                 mfu_walk_opts_t* walk_opts,
                                 mfu_flist flist,
@@ -715,13 +727,14 @@ void mfu_flist_walk_param_paths(uint64_t num,
 {
     /* allocate memory to hold a list of paths */
     const char** path_list = (const char**) MFU_MALLOC(num * sizeof(char*));
+    int walk_result;
 
 #ifdef DAOS_SUPPORT
     /* DAOS only supports using one source path */
     if (mfu_file->type == DFS) {
         if (num != 1) {
             MFU_LOG(MFU_LOG_ERR, "Only one source can be specified when using DAOS");
-            return;
+            return EINVAL;
         }
     }
 #endif
@@ -734,12 +747,12 @@ void mfu_flist_walk_param_paths(uint64_t num,
     }
 
     /* walk file tree and record stat data for each file */
-    mfu_flist_walk_paths((uint64_t) num, path_list, walk_opts, flist, mfu_file);
+    walk_result = mfu_flist_walk_paths((uint64_t) num, path_list, walk_opts, flist, mfu_file);
 
     /* free the list */
     mfu_free(&path_list);
 
-    return;
+    return walk_result;
 }
 
 /* Given an input file list, stat each file and enqueue details
@@ -806,6 +819,7 @@ void mfu_flist_stat(
             if (status != 0) {
                 MFU_LOG(MFU_LOG_ERR, "mfu_file_stat() failed: '%s' rc=%d (errno=%d %s)",
                         name, status, errno, strerror(errno));
+                WALK_RESULT = errno;
                 continue;
             }
         } else {
@@ -814,6 +828,7 @@ void mfu_flist_stat(
             if (status != 0) {
                 MFU_LOG(MFU_LOG_ERR, "mfu_file_lstat() failed: '%s' rc=%d (errno=%d %s)",
                         name, status, errno, strerror(errno));
+                WALK_RESULT = errno;
                 continue;
             }
         }

--- a/src/dchmod/dchmod.c
+++ b/src/dchmod/dchmod.c
@@ -249,7 +249,7 @@ int main(int argc, char** argv)
         }
 
         /* walk list of input paths */
-        mfu_flist_walk_param_paths(numpaths, paths, walk_opts, flist, mfu_file);
+        (void) mfu_flist_walk_param_paths(numpaths, paths, walk_opts, flist, mfu_file);
     }
     else {
         /* read list from file */

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -2330,12 +2330,12 @@ int main(int argc, char **argv)
     if (rank == 0) {
         MFU_LOG(MFU_LOG_INFO, "Walking source path");
     }
-    mfu_flist_walk_param_paths(1,  srcpath, walk_opts, flist1, mfu_src_file);
+    (void) mfu_flist_walk_param_paths(1,  srcpath, walk_opts, flist1, mfu_src_file);
 
     if (rank == 0) {
         MFU_LOG(MFU_LOG_INFO, "Walking destination path");
     }
-    mfu_flist_walk_param_paths(1, destpath, walk_opts, flist2, mfu_dst_file);
+    (void) mfu_flist_walk_param_paths(1, destpath, walk_opts, flist2, mfu_dst_file);
 
     /* store src and dest path strings */
     const char* path1 = srcpath->path;

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -526,7 +526,7 @@ int main(int argc, char** argv)
         /* perform POSIX copy */
         if (inputname == NULL) {
             /* if daos is set to SRC then use daos_ functions on walk */
-            mfu_flist_walk_param_paths(numpaths_src, paths, walk_opts, flist, mfu_src_file);
+            (void) mfu_flist_walk_param_paths(numpaths_src, paths, walk_opts, flist, mfu_src_file);
         } else {
             struct mfu_flist_skip_args skip_args;
 

--- a/src/dfind/dfind.c
+++ b/src/dfind/dfind.c
@@ -669,7 +669,7 @@ daos_setup_done:
 
     if (walk) {
         /* walk list of input paths */
-        mfu_flist_walk_param_paths(numpaths, paths, walk_opts, flist, mfu_file);
+        (void) mfu_flist_walk_param_paths(numpaths, paths, walk_opts, flist, mfu_file);
     }
     else {
         /* read data from cache file */

--- a/src/dreln/dreln.c
+++ b/src/dreln/dreln.c
@@ -224,7 +224,7 @@ int main (int argc, char* argv[])
     /* get source file list */
     if (walk) {
         /* walk list of input paths */
-        mfu_flist_walk_param_paths(numpaths, paths, walk_opts, flist, mfu_file);
+        (void) mfu_flist_walk_param_paths(numpaths, paths, walk_opts, flist, mfu_file);
     } else {
         /* read cache file */
         mfu_flist_read_cache(inputname, flist);

--- a/src/drm/drm.c
+++ b/src/drm/drm.c
@@ -335,7 +335,7 @@ daos_setup_done:
      * input file */
     if (walk) {
         /* walk list of input paths */
-        mfu_flist_walk_param_paths(numpaths, paths, walk_opts, flist, mfu_file);
+        (void) mfu_flist_walk_param_paths(numpaths, paths, walk_opts, flist, mfu_file);
     }
     else {
         /* read list from file */

--- a/src/dstripe/dstripe.c
+++ b/src/dstripe/dstripe.c
@@ -553,7 +553,7 @@ int main(int argc, char* argv[])
     /* walk list of input paths and stat as we walk */
     mfu_flist flist = mfu_flist_new();
 
-    mfu_flist_walk_param_paths(numpaths, paths, walk_opts, flist, mfu_file);
+    (void) mfu_flist_walk_param_paths(numpaths, paths, walk_opts, flist, mfu_file);
 
     /* filter down our list to files which don't meet our striping requirements */
     mfu_flist filtered = filter_list(flist, stripes, stripe_size, min_size, &create_prog_count_total, &stripe_prog_bytes_total);

--- a/src/dtar/dtar.c
+++ b/src/dtar/dtar.c
@@ -418,7 +418,7 @@ int main(int argc, char** argv)
 
         /* walk path to get stats info on all files */
         mfu_flist flist = mfu_flist_new();
-        mfu_flist_walk_param_paths(numpaths, paths, walk_opts, flist, mfu_src_file);
+        (void) mfu_flist_walk_param_paths(numpaths, paths, walk_opts, flist, mfu_src_file);
 
         /* we may need to add parent directories between the cwd
          * and the source paths the user specified */

--- a/src/dwalk/dwalk.c
+++ b/src/dwalk/dwalk.c
@@ -654,7 +654,7 @@ daos_setup_done:
 
     if (walk) {
         /* walk list of input paths */
-        mfu_flist_walk_param_paths(numpaths, paths, walk_opts, flist, mfu_file);
+        (void) mfu_flist_walk_param_paths(numpaths, paths, walk_opts, flist, mfu_file);
     }
     else {
         /* read data from cache file */

--- a/test/tests/test_dsync/test_walkfail.sh
+++ b/test/tests/test_dsync/test_walkfail.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+
+. utility/set_funcs.sh
+
+##############################################################################
+# Description:
+#
+#   Verify dsync handles an error during source or destination walk correctly
+#     - source walk fails without --delete arg
+#     - source walk fails with --delete arg
+#     - destination walk fails without --delete arg
+#     - destination walk fails with --delete arg
+#
+# Notes:
+#   Need to figure out what correct behavior is for all the above cases, and
+#   document what we decide on.  One source of ideas is the rsync man page.
+#
+##############################################################################
+
+# Turn on verbose output
+#set -x
+
+DSYNC_TEST_BIN=${DSYNC_TEST_BIN:-${1}}
+DSYNC_SRC_BASE=${DSYNC_SRC_BASE:-${2}}
+DSYNC_DEST_BASE=${DSYNC_DEST_BASE:-${3}}
+DSYNC_TREE_NAME=${DSYNC_TREE_NAME:-${4}}
+
+DSYNC_TREE_DATA=/usr/include/c++
+
+mpirun=$(which mpirun 2>/dev/null)
+mpirun_opts=""
+if [[ -n $mpirun ]]; then
+	procs=$(( $(nproc ) / 8 ))
+	if [[ $procs -gt 16 ]]; then
+		procs=16
+	fi
+	mpirun_opts="-c $procs"
+
+	echo "Using mpirun: $mpirun $mpirun_opts"
+fi
+
+echo "Using dsync binary at: $DSYNC_TEST_BIN"
+echo "Using src parent directory at: $DSYNC_SRC_BASE"
+echo "Using dest parent directory at: $DSYNC_DEST_BASE"
+echo "Using test data from: $DSYNC_TREE_DATA"
+
+DSYNC_SRC_DIR=$(mktemp --directory ${DSYNC_SRC_BASE}/${DSYNC_TREE_NAME}.XXXXX)
+DSYNC_DEST_DIR=$(mktemp --directory ${DSYNC_DEST_BASE}/${DSYNC_TREE_NAME}.XXXXX)
+
+function fs_type()
+{
+	fname=$1
+	df -T ${fname} | awk '$1 != "Filesystem" {print $2}'
+}
+
+function list_all_files()
+{
+	find $1 -printf '%P\n' | sort | grep -v '^$'
+}
+
+function sync_and_verify()
+{
+	local srcdir=$1
+	local destdir=$2
+	local name=$3
+	local expectation=$4
+
+	local result=0
+	local dest_type=""
+
+	src_list=$(mktemp /tmp/sync_and_verify.src.XXXXX)
+	list_all_files $srcdir > $src_list
+
+	dest_list=$(mktemp /tmp/sync_and_verify.dest.XXXXX)
+
+	# dest may not exist, but its parent must exist
+	if [[ -d $destdir ]]; then
+		dest_type=$(fs_type $destdir)
+		list_all_files $destdir > $dest_list
+	else
+		parent=$(dirname $destdir)
+		if [[ ! -d $parent ]]; then
+			echo "sync_and_verify: destdir $destdir and its parent do not exist"
+			exit 1
+		fi
+		dest_type=$(fs_type $parent)
+	fi
+
+	quiet_opt="--quiet"
+	delete_opt=""
+	if [[ $name = "delete" ]]; then
+		delete_opt="--delete"
+	fi
+
+	if [[ -n $mpirun ]]; then
+		$mpirun $mpirun_opts $DSYNC_TEST_BIN $quiet_opt $delete_opt $srcdir $destdir
+	else
+		$DSYNC_TEST_BIN $quiet_opt $delete_opt $srcdir $destdir
+	fi
+	rc=$?
+
+	if [[ $rc -ne 0 ]]; then
+		echo "dsync failed with rc $rc"
+		result=1
+	fi
+
+	if [[ $expectation = "union" && $name = "delete" ]]; then
+		# dsync will have copied the "000" perms on destination, which would prevent us
+		# from walking to get true "after list".  Change that, our test is just verifying
+		# presence or absence of files, not metadata set on destination.
+		chmod 755 $DSYNC_DEST_DIR/stuff/on/both/trees
+	fi
+
+	if [[ $result -eq 0 ]]; then
+		after_list=$(mktemp /tmp/sync_and_verify.after.XXXXX)
+		list_all_files $destdir > $after_list
+
+		expected_list=$(mktemp /tmp/sync_and_verify.expected.XXXXX)
+
+		case $expectation in
+		  "union")
+			union $src_list $dest_list > $expected_list
+			;;
+		  "src_exactly")
+			cat $src_list > $expected_list
+			;;
+		esac
+
+		sets_equal $after_list $expected_list
+		result=$?
+	fi
+
+	if [ "$result" -eq 0 ]; then
+		echo "PASSED verify of option $name for $destdir type $dest_type"
+	else
+		echo "FAILED verify of option $name for $destdir type $dest_type"
+		echo =======================
+		echo "before: src_list"
+		cat $src_list
+		echo
+		echo "before: dest_list"
+		cat $dest_list
+		echo
+		echo "after: after_list:"
+		cat $after_list
+		echo
+		echo "expected:"
+		cat $expected_list
+		echo =======================
+	fi
+
+	rm $src_list $dest_list $after_list $expected_list
+
+	return $result
+}
+
+# source walk fails without --delete arg
+# not implemented
+
+# destination walk fails without --delete arg
+# not implemented
+
+# destination walk fails with --delete arg
+# not implemented
+
+# source walk fails with --delete arg
+# no files or directories on destination are deleted
+# subset of source files discovered before walk failure are copied to test
+
+rm -fr $DSYNC_SRC_DIR/stuff
+rm -fr $DSYNC_DEST_DIR/stuff
+mkdir $DSYNC_SRC_DIR/stuff
+mkdir $DSYNC_DEST_DIR/stuff
+
+mkdir -p  $DSYNC_SRC_DIR/stuff/on/both/trees/deepdir
+mkdir     $DSYNC_SRC_DIR/stuff/on/both/shallow
+mkdir -p $DSYNC_DEST_DIR/stuff/on/both/trees/deepdir
+mkdir    $DSYNC_DEST_DIR/stuff/on/both/shallow
+
+# not reachable during walk due to permissions
+chmod 000 $DSYNC_SRC_DIR/stuff/on/both/trees
+
+# delete should be disabled, so no files deleted
+# non-walkable src will not be copied, but also not in "$src_list"
+# union is of walkable part of src dir and dest dir (all walkable)
+sync_and_verify  $DSYNC_SRC_DIR/stuff $DSYNC_DEST_DIR/stuff delete union
+
+# clean up
+chmod 755 $DSYNC_SRC_DIR/stuff/on/both/trees
+chmod 755 $DSYNC_DEST_DIR/stuff/on/both/trees
+rm -fr $DSYNC_SRC_DIR/stuff
+rm -fr $DSYNC_DEST_DIR/stuff
+
+exit 0


### PR DESCRIPTION
In dsync, if there was an error during the walk of the source tree, the source flist generated is likely incomplete.

In the case where the source and destination have the same files and directories before dsync --delete is run, an incomplete source flist results in files being incorrectly deleted from the destination.

When an error was detected for the source walk, warn the user and disable the --delete option.  Continue with the dsync, so that any new files identified are still copied and metadata is synced.

See rsync(1) for the --delete option, it takes the same approach.

Implement a test where dsync --delete is run, and the walk of the source tree is caused to fail by making a directory unreadable.

Before the patch, the test detects that files on the destination are deleted when they should not be, due to the error during the source walk.  After the patch, the test shows the improper deletes do not occur.

Fixes #587
