### PR TITLE
mfu_flist_walk.c: set WALK_RESULT = -1

### DIFF
--- a/src/dsync/dsync.c
+++ b/src/dsync/dsync.c
@@ -3318,8 +3318,8 @@ int main(int argc, char **argv)
      * and a delete might delete files already on the destination.  Disable the delete and
      * notify the user. rsync takes the same approach. */
     int all_rc;
-    MPI_Allreduce(&walk_rc, &all_rc, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
-    if (all_rc > 0) {
+    MPI_Allreduce(&walk_rc, &all_rc, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+    if (all_rc != 0) {
         if (options.delete == 1) {
             if (rank == 0) {
                 MFU_LOG(MFU_LOG_ERR, "Errors detected walking source path, delete option disabled");


### PR DESCRIPTION
Fixes issues identified in the code review of #599

Since WALK_RESULT is an int and can only hold one error code, but any number of errors might be encountered during a walk, there is little value in recording errno.

In addition, the value of errno might have changed unless it is captured immediately after the library or system call that failed, which would require deeper code changes.

Instead, set to -1 as the indicator of a failure.