### PR TITLE
fix bufsize typo in mfu_copy_xattrs and DCOPY_copy_xattrs

### DIFF
--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -279,7 +279,7 @@ static int mfu_copy_xattrs(
     const char* src_path = mfu_flist_file_get_name(flist, idx);
 
     /* start with a reasonable buffer, we'll allocate more as needed */
-    size_t list_bufsize = 1204;
+    size_t list_bufsize = 1024;
     char* list = (char*) MFU_MALLOC(list_bufsize);
 
     /* get list, if list_size == ERANGE, try again */

--- a/src/dcp1/common.c
+++ b/src/dcp1/common.c
@@ -335,7 +335,7 @@ void DCOPY_copy_xattrs(
     char* src_path = op->operand;
 
     /* start with a reasonable buffer, we'll allocate more as needed */
-    size_t list_bufsize = 1204;
+    size_t list_bufsize = 1024;
     char* list = (char*) MFU_MALLOC(list_bufsize);
 
     /* get list, if list_size == ERANGE, try again */


### PR DESCRIPTION
Initial buffer allocated is size 1204.  The intended size was 1024, indicated in the commit message (below).  1024 fits better in PAGE_SIZE and so may slightly improve memory management.

The typo was originally introduced into DCOPY_copy_xattrs(), then the code was copied into mfu_copy_xattrs() as part of later work.

The original commit that introduced the typo was:

	commit 9a211b5f48f322d439b6f03dda6009dbff78e4c3
	Author: Adam Moody <moody20@llnl.gov>
	Date:   Thu Nov 21 14:19:59 2013 -0800

	    start out with 1024 byte buffer for xattrs