### PR TITLE
Fix compile warnings

### DIFF
--- a/src/common/mfu_io.c
+++ b/src/common/mfu_io.c
@@ -1670,4 +1670,4 @@ int daos_lsetxattr(const char* path, const char* name, const void* value, size_t
     return mfu_errno2rc(ENOSYS);
 #endif
 }
-#endif DCOPY_USE_XATTRS
+#endif // DCOPY_USE_XATTRS

--- a/src/dcp/dcp.c
+++ b/src/dcp/dcp.c
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <grp.h>
 
 /* for daos */
 #ifdef DAOS_SUPPORT
@@ -116,7 +117,7 @@ int main(int argc, char** argv)
     /* effective group/user id */
     uid_t egid = 0, euid = 0;
     uid_t gid = getegid(), uid = geteuid();
-    uid_t gids[MAX_GIDS];
+    gid_t gids[MAX_GIDS];
     int gids_count = 0;
 
     /* initialize MPI */
@@ -404,7 +405,7 @@ int main(int argc, char** argv)
     /* setgroups before set gid or uid */
     if (egid > 0 || euid > 0) {
         /* record the original groups */
-        gids_count = getgroups(MAX_GIDS, &gids);
+        gids_count = getgroups(MAX_GIDS, gids);
         if (gids_count < 0) {
             MFU_LOG(MFU_LOG_ERR, "Could not getgroups: %s", strerror(errno));
             mfu_finalize();


### PR DESCRIPTION
Fix three compile warnings observed when building with gcc (GCC) 12.2.1 20221121 (Red Hat 12.2.1-7)

1. Extra token at end of `#endif`
``` 
            [ 21%] Building C object src/common/CMakeFiles/mfu_o.dir/mfu_io.c.o
            src/common/mfu_io.c:1673:8: warning: extra tokens at end of #endif directive [-Wendif-labels]
             1673 | #endif DCOPY_USE_XATTRS
                  |        ^~~~~~~~~~~~~~~~
 ```
2. Implicit declaration of `setgroups()`
```
            src/dcp/dcp.c:416:13: warning: implicit declaration of function ‘setgroups’; did you mean ‘getgroups’? [-Wimplicit-function-declaration]
              416 |         if (setgroups(0, NULL) < 0) {
                  |             ^~~~~~~~~
                  |             getgroups
            [ 50%] Linking C executable dcp
```

3. Incorrect type passed to `getgroups()`
```
            src/dcp/dcp.c:407:42: warning: passing argument 2 of ‘getgroups’ from incompatible pointer type [-Wincompatible-pointer-types]
              407 |         gids_count = getgroups(MAX_GIDS, &gids);
                  |                                          ^~~~~
                  |                                          |
                  |                                          uid_t (*)[100] {aka unsigned int (*)[100]}
            In file included from src/dcp/dcp.c:7:
            /usr/include/unistd.h:689:43: note: expected ‘__gid_t *’ {aka ‘unsigned int *’} but argument is of type ‘uid_t (*)[100]’ {aka ‘unsigned int (*)[100]’}
              689 | extern int getgroups (int __size, __gid_t __list[]) __THROW __wur;
```
