### PR TITLE
.gitignore: ignore tags file created by ctags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ spack.lock
 
 # Code editors
 .vscode
+
+# source indexing/tagging
+tags


### PR DESCRIPTION
Ignore the index file created by ctags.  The index file(s) created by cscope are already ignored as a side affect of an existing entry:

```
>   16 # Executables
>   17 *.exe
>>> 18 *.out
>   19 *.app
```