### PR TITLE
dfilemaker: implement --verbose, add modelines, and refactor some code

### DIFF
--- a/src/dfilemaker/dfilemaker.c
+++ b/src/dfilemaker/dfilemaker.c
@@ -674,7 +674,7 @@ int main(int narg, char** arg)
     MPI_Init(&narg, &arg);
     DTCMP_Init();
     mfu_init();
-    mfu_debug_level = MFU_LOG_VERBOSE;
+    mfu_debug_level = MFU_LOG_WARN;
 
     int rank, nrank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -757,8 +757,8 @@ int main(int narg, char** arg)
               widmax=atoi(maxterm);
               break;
             case 'v':
-              if (rank == 0) {
-                  MFU_LOG(MFU_LOG_DBG,"verbose is on");
+              if (mfu_debug_level < MFU_LOG_DBG) {
+                  mfu_debug_level++;
               }
               break;
             case 'h':
@@ -767,7 +767,7 @@ int main(int narg, char** arg)
               }
               mfu_finalize();
               MPI_Finalize();
-	      exit(0);
+              exit(0);
               break;
             default:
               break;

--- a/src/dfilemaker/dfilemaker.c
+++ b/src/dfilemaker/dfilemaker.c
@@ -1336,3 +1336,5 @@ int main(int narg, char** arg)
 
     return 0;
 }
+
+//  vim: et ts=4 :

--- a/src/dfilemaker/dfilemaker.c
+++ b/src/dfilemaker/dfilemaker.c
@@ -78,7 +78,7 @@ int tnamcomp(const void* a, const void* b)
     return rc;
 }
 
-static void print_summary(mfu_flist flist)
+static void print_summary(mfu_flist flist, int level)
 {
     /* get our rank and the size of comm_world */
     int rank, ranks;
@@ -784,11 +784,6 @@ int main(int narg, char** arg)
      if (sizemax > 0) {
          maxflen=sizemin+rand()%(1+sizemax-sizemin);
      }
-     if (rank == 0 ) {
-         printf("ntotal = %d\n",ntotal);
-         printf("nlevels = %d\n",nlevels);
-         printf("maxflen = %d\n",maxflen);
-     }
 
     /*-------------------------------------------------------
      * each level has nfiles[0] more than the one above
@@ -892,7 +887,8 @@ int main(int narg, char** arg)
     //-----------------------------
     MPI_Barrier(MPI_COMM_WORLD);
     mfu_flist_summarize(mybflist);
-    print_summary(mybflist);
+
+    print_summary(mybflist, 0);
     MPI_Barrier(MPI_COMM_WORLD);
     mfu_free(&ftypes);
     mfu_free(&flens);
@@ -904,9 +900,6 @@ int main(int narg, char** arg)
     lndirs = (int*) MFU_MALLOC(nrank * sizeof(int));
     ddispls = (int*) MFU_MALLOC(nrank * sizeof(int));
     for (ilev = 1; ilev < nlevels; ilev++) {
-        if (rank == 0) {
-            printf("ilev = %d\n", ilev);
-        }
         nfsum += nfiles[ilev - 1];
         ifrac = (nfiles[ilev] + nrank - 1) / nrank;
         ifst = rank * ifrac;
@@ -1056,7 +1049,7 @@ int main(int narg, char** arg)
         total_unknown = 0;
         total_bytes   = 0;
         mfu_flist_summarize(mybflist);
-        print_summary(mybflist);
+        print_summary(mybflist, ilev);
         MPI_Barrier(MPI_COMM_WORLD);
         mfu_free(&randir);
         mfu_free(&ftypes);

--- a/src/dfilemaker/dfilemaker.c
+++ b/src/dfilemaker/dfilemaker.c
@@ -541,6 +541,23 @@ void lnamunsort(char** buff, char** tarray, int* lind, int nitems)
     }
 }
 
+/*---------------------------------------------------------------------
+*  shortopts below are followed by a colon if they take an argument
+*---------------------------------------------------------------------*/
+static char *short_options = "i:f:d:n:r:s:w:vh";
+static struct option long_options[] = {
+    {"seed",     1, 0, 'i'},
+    {"fill",     1, 0, 'f'},
+    {"depth",    1, 0, 'd'},
+    {"nitems",   1, 0, 'n'},
+    {"ratio",    1, 0, 'r'},
+    {"size",     1, 0, 's'},
+    {"width",    1, 0, 'w'},
+    {"version",  0, 0, 'v'},
+    {"help",     0, 0, 'h'},
+    {0, 0, 0, 0}
+};
+
 /*-----------------------*/
 /* Print help message */
 /*-----------------------*/
@@ -669,10 +686,7 @@ int main(int narg, char** arg)
     *  loop over options
     *---------------------*/
     while (1) {
-       /*---------------------------------------------------------------------
-        *  shortopts below are followed by a colon if they take an argument
-        *---------------------------------------------------------------------*/
-        c=getopt_long(narg,arg,"i:f:d:n:r:s:w:vh",long_options,&longind);
+        c=getopt_long(narg,arg,short_options,long_options,&longind);
         if (c <= 0) break;
         minterm=(char*)MFU_MALLOC(10*sizeof(char));
         maxterm=(char*)MFU_MALLOC(10*sizeof(char));


### PR DESCRIPTION
* clarify file/dir/link counts per level
    
    In debug output, when reporting file/dir/link counts, specify what level
    of the generated tree those elements are at.

* add vim modeline
    
    Add vim modeline to prevent introducing tabs instead of spaces,
    by vim users.
    
* implement option --verbose/-v
    
    Make default verbosity is MFU_LOG_WARN.
    
    Each instance of -v in the options increases level up to MFU_LOG_DBG,
    which is the maximum verbosity level.
    
* define options near print_usage()
    
    Define the strings passed to getopt_long, short_options and
    long_options, next to each other and next to print_usage() so
    it's easier to ensure they stay synchronized with each other.