### PR TITLE
dfilemaker: pass correct pointer to mfu_free()

### DIFF
--- a/src/dfilemaker/dfilemaker.c
+++ b/src/dfilemaker/dfilemaker.c
@@ -1072,7 +1072,7 @@ int main(int narg, char** arg)
     mfu_flist_mkdir(mybflist, create_opts);
     mfu_flist_mknod(mybflist, create_opts);
     write_files(mybflist, filltype);
-    mfu_free(buf); // used only in write_files()->write_file()
+    mfu_free(&buf); // used only in write_files()->write_file()
     mfu_create_opts_delete(&create_opts);
 
     //------------------------------------


### PR DESCRIPTION
Commit
	commit fc70c2ce3d7499685697157db91ccd645f2b031e
	Author: Olaf Faaland <faaland1@llnl.gov>
	Date:   Thu Nov 14 15:44:34 2024 -0800

	dfilemaker: address review comments for PR #269

introduced an error.  mfu_free() takes a pointer to a pointer, because it both frees the memory, and also sets the pointer to NULL to prevent double-free bugs.

The above commit passed the address of the memory to be freed, not the address of the pointer.  This meant both that the wrong memory was freed, potentially, and also that the code attempted to set some arbitrary set of bytes to NULL.

In testing, this triggered a segfault when running dfilemaker.