### PR TITLE
dfilemaker: exit on unrecognized option and remove duplicate longopts struct

### DIFF
--- a/src/dfilemaker/dfilemaker.c
+++ b/src/dfilemaker/dfilemaker.c
@@ -553,7 +553,7 @@ static struct option long_options[] = {
     {"ratio",    1, 0, 'r'},
     {"size",     1, 0, 's'},
     {"width",    1, 0, 'w'},
-    {"version",  0, 0, 'v'},
+    {"verbose",  0, 0, 'v'},
     {"help",     0, 0, 'h'},
     {0, 0, 0, 0}
 };
@@ -574,7 +574,7 @@ static void print_usage(void)
     printf("  -r, --ratio=*min*-*max*   - ratio of files to directories as a percent (not implemented)\n");
     printf("  -s, --size=*min*-*max*    - file size, integers min and max followed by MB or GB\n");
     printf("  -w, --width=*min*-*max*   - directory width, integers min and max (not implemented)\n");
-    printf("  -v, --verbose             - print version number\n");
+    printf("  -v, --verbose             - increase verbosity of output; default is INFO\n");
     printf("  -h, --help                - print usage\n");
     printf("\n");
     printf("For more information see https://mpifileutils.readthedocs.io.\n");
@@ -655,18 +655,6 @@ int main(int narg, char** arg)
     int depmin=0,depmax=0;
     int nmin=0,nmax=0;
     int widmin=0,widmax=0;
-    static struct option long_options[] = {
-       {"seed",     1, 0, 'i'},
-       {"fill",     1, 0, 'f'},
-       {"depth",    1, 0, 'd'},
-       {"nitems",   1, 0, 'n'},
-       {"ratio",    1, 0, 'r'},
-       {"size",     1, 0, 's'},
-       {"width",    1, 0, 'w'},
-       {"version",  0, 0, 'v'},
-       {"help",     0, 0, 'h'},
-       {0, 0, 0, 0}
-    };
 
     /*--------------------------
      * initialize mfu and MPI

--- a/src/dfilemaker/dfilemaker.c
+++ b/src/dfilemaker/dfilemaker.c
@@ -770,7 +770,13 @@ int main(int narg, char** arg)
               exit(0);
               break;
             default:
-              break;
+              /* unrecognized option */
+              if (rank == 0) {
+                  print_usage();
+              }
+              mfu_finalize();
+              MPI_Finalize();
+              exit(1);
         }
      }
 


### PR DESCRIPTION

(1) A duplicate longopts struct introduced during a rebase, when creating a PR to add
    
            commit 1187ecf27e5ffb76b5a2ee0334d3b0925c0b32ff
            Author: Olaf Faaland <faaland1@llnl.gov>
            Date:   Thu Nov 21 16:19:03 2024 -0800
    
                dfilemaker: define options near print_usage()
    
                Define the strings passed to getopt_long, short_options and
                long_options, next to each other and next to print_usage() so
                it's easier to ensure they stay synchronized with each other.
    
                Signed-off-by: Olaf Faaland <faaland1@llnl.gov>
    
(2) In addition, when adding support for "--verbose", some parts of the code
    were changed from "version" to "verbose", but some were missed.
    
(3) If getopt_long() encounters an unknown option, print usage information
    and stop execution.
    
Continuing to process options and create files, after encountering an
unknown option, will create a file tree different than the one the user
 intended.  For example, if the user mistypes the option for file size,
e.g.
      "--sizeRRR=2MB-10000GB"
 instead of
      "--size=2MB-10000GB"
    
proceeding would mean we use the default file size range when
constructing the tree instead of the one the user intended.