### PR TITLE
test_dsync/test_existence.sh: use dfilemaker for test data

### DIFF
--- a/test/tests/test_dsync/test_data.sh
+++ b/test/tests/test_dsync/test_data.sh
@@ -16,12 +16,12 @@
 # Turn on verbose output
 #set -x
 
-DSYNC_TEST_BIN=${DSYNC_TEST_BIN:-${1}}
+MFU_TEST_BIN=${MFU_TEST_BIN:-${1}}
 DSYNC_SRC_DIR=${DSYNC_SRC_DIR:-${2}}
 DSYNC_DEST_DIR=${DSYNC_DEST_DIR:-${3}}
 DSYNC_TMP_FILE=${DSYNC_TMP_FILE:-${4}}
 
-echo "Using dsync binary at: $DSYNC_TEST_BIN"
+echo "Using MFU binaries at: $MFU_TEST_BIN"
 echo "Using src directory at: $DSYNC_SRC_DIR"
 echo "Using dest directory at: $DSYNC_DEST_DIR"
 echo "Using directory tree: $DSYNC_TMP_FILE"

--- a/test/tests/test_dsync/test_existence.sh
+++ b/test/tests/test_dsync/test_existence.sh
@@ -27,8 +27,6 @@ DSYNC_SRC_BASE=${DSYNC_SRC_BASE:-${2}}
 DSYNC_DEST_BASE=${DSYNC_DEST_BASE:-${3}}
 DSYNC_TREE_NAME=${DSYNC_TREE_NAME:-${4}}
 
-DSYNC_TREE_DATA=/usr/include/c++
-
 mpirun=$(which mpirun 2>/dev/null)
 mpirun_opts=""
 if [[ -n $mpirun ]]; then
@@ -44,7 +42,6 @@ fi
 echo "Using MFU binaries at: $MFU_TEST_BIN"
 echo "Using src parent directory at: $DSYNC_SRC_BASE"
 echo "Using dest parent directory at: $DSYNC_DEST_BASE"
-echo "Using test data from: $DSYNC_TREE_DATA"
 
 DSYNC_SRC_DIR=$(mktemp --directory ${DSYNC_SRC_BASE}/${DSYNC_TREE_NAME}.XXXXX)
 DSYNC_DEST_DIR=$(mktemp --directory ${DSYNC_DEST_BASE}/${DSYNC_TREE_NAME}.XXXXX)
@@ -156,7 +153,7 @@ rm -fr $DSYNC_SRC_DIR/stuff
 rm -fr $DSYNC_DEST_DIR/stuff
 mkdir $DSYNC_SRC_DIR/stuff
 mkdir $DSYNC_DEST_DIR/stuff
-cp -a $DSYNC_TREE_DATA $DSYNC_DEST_DIR/stuff
+${MFU_TEST_BIN}/dfilemaker --depth 5-10 --nitems 100-300 --size 1MB-10MB $DSYNC_DEST_DIR/stuff
 sync_and_verify  $DSYNC_SRC_DIR/stuff $DSYNC_DEST_DIR/stuff empty_source union
 
 # non-empty source, but empty destination
@@ -165,7 +162,7 @@ sync_and_verify  $DSYNC_SRC_DIR/stuff $DSYNC_DEST_DIR/stuff empty_source union
 rm -fr $DSYNC_SRC_DIR/stuff
 rm -fr $DSYNC_DEST_DIR/stuff
 mkdir $DSYNC_SRC_DIR/stuff
-cp -a $DSYNC_TREE_DATA $DSYNC_SRC_DIR/stuff
+${MFU_TEST_BIN}/dfilemaker --depth 5-10 --nitems 100-300 --size 1MB-10MB $DSYNC_SRC_DIR/stuff
 sync_and_verify  $DSYNC_SRC_DIR/stuff $DSYNC_DEST_DIR/stuff empty_destination union
 
 # directories on destination, but not source, are removed with --delete
@@ -174,7 +171,7 @@ rm -fr $DSYNC_SRC_DIR/stuff
 rm -fr $DSYNC_DEST_DIR/stuff
 mkdir $DSYNC_SRC_DIR/stuff
 mkdir $DSYNC_DEST_DIR/stuff
-cp -a $DSYNC_TREE_DATA $DSYNC_SRC_DIR/stuff
+${MFU_TEST_BIN}/dfilemaker --depth 5-10 --nitems 100-300 --size 1MB-10MB $DSYNC_SRC_DIR/stuff
 mkdir $DSYNC_DEST_DIR/stuff/destdir
 touch $DSYNC_DEST_DIR/stuff/destfile
 sync_and_verify  $DSYNC_SRC_DIR/stuff $DSYNC_DEST_DIR/stuff delete src_exactly

--- a/test/tests/test_dsync/test_existence.sh
+++ b/test/tests/test_dsync/test_existence.sh
@@ -22,7 +22,7 @@
 # Turn on verbose output
 #set -x
 
-DSYNC_TEST_BIN=${DSYNC_TEST_BIN:-${1}}
+MFU_TEST_BIN=${MFU_TEST_BIN:-${1}}
 DSYNC_SRC_BASE=${DSYNC_SRC_BASE:-${2}}
 DSYNC_DEST_BASE=${DSYNC_DEST_BASE:-${3}}
 DSYNC_TREE_NAME=${DSYNC_TREE_NAME:-${4}}
@@ -41,7 +41,7 @@ if [[ -n $mpirun ]]; then
 	echo "Using mpirun: $mpirun $mpirun_opts"
 fi
 
-echo "Using dsync binary at: $DSYNC_TEST_BIN"
+echo "Using MFU binaries at: $MFU_TEST_BIN"
 echo "Using src parent directory at: $DSYNC_SRC_BASE"
 echo "Using dest parent directory at: $DSYNC_DEST_BASE"
 echo "Using test data from: $DSYNC_TREE_DATA"
@@ -95,9 +95,9 @@ function sync_and_verify()
 	fi
 
 	if [[ -n $mpirun ]]; then
-		$mpirun $mpirun_opts $DSYNC_TEST_BIN $quiet_opt $delete_opt $srcdir $destdir
+		$mpirun $mpirun_opts ${MFU_TEST_BIN}/dsync $quiet_opt $delete_opt $srcdir $destdir
 	else
-		$DSYNC_TEST_BIN $quiet_opt $delete_opt $srcdir $destdir
+		${MFU_TEST_BIN}/dsync $quiet_opt $delete_opt $srcdir $destdir
 	fi
 	rc=$?
 

--- a/test/tests/test_dsync/test_expectfail.sh
+++ b/test/tests/test_dsync/test_expectfail.sh
@@ -16,12 +16,12 @@
 # Turn on verbose output
 #set -x
 
-DSYNC_TEST_BIN=${DSYNC_TEST_BIN:-${1}}
+MFU_TEST_BIN=${MFU_TEST_BIN:-${1}}
 DSYNC_SRC_BASE=${DSYNC_SRC_BASE:-${2}}
 DSYNC_DEST_BASE=${DSYNC_DEST_BASE:-${3}}
 DSYNC_TREE_NAME=${DSYNC_TREE_NAME:-${4}}
 
-echo "Using dsync binary at: $DSYNC_TEST_BIN"
+echo "Using MFU binaries at: $MFU_TEST_BIN"
 echo "Using src parent directory at: $DSYNC_SRC_BASE"
 echo "Using dest parent directory at: $DSYNC_DEST_BASE"
 
@@ -40,7 +40,7 @@ function sync_and_verify()
 
 	quiet_opt="--quiet"
 
-	$DSYNC_TEST_BIN $quiet_opt $delete_opt $srcdir $destdir
+	${MFU_TEST_BIN}/dsync $quiet_opt $delete_opt $srcdir $destdir
 	rc=$?
 	echo "dsync failed with rc $rc"
 

--- a/test/tests/test_dsync/test_metadata.sh
+++ b/test/tests/test_dsync/test_metadata.sh
@@ -15,12 +15,12 @@
 # Turn on verbose output
 #set -x
 
-DSYNC_TEST_BIN=${DSYNC_TEST_BIN:-${1}}
+MFU_TEST_BIN=${MFU_TEST_BIN:-${1}}
 DSYNC_SRC_DIR=${DSYNC_SRC_DIR:-${2}}
 DSYNC_DEST_DIR=${DSYNC_DEST_DIR:-${3}}
 DSYNC_TMP_FILE=${DSYNC_TMP_FILE:-${4}}
 
-echo "Using dsync binary at: $DSYNC_TEST_BIN"
+echo "Using MFU binaries at: $MFU_TEST_BIN"
 echo "Using src directory at: $DSYNC_SRC_DIR"
 echo "Using dest directory at: $DSYNC_DEST_DIR"
 echo "Using directory tree: $DSYNC_TMP_FILE"

--- a/test/tests/test_dsync/test_walkfail.sh
+++ b/test/tests/test_dsync/test_walkfail.sh
@@ -20,7 +20,7 @@
 # Turn on verbose output
 #set -x
 
-DSYNC_TEST_BIN=${DSYNC_TEST_BIN:-${1}}
+MFU_TEST_BIN=${MFU_TEST_BIN:-${1}}
 DSYNC_SRC_BASE=${DSYNC_SRC_BASE:-${2}}
 DSYNC_DEST_BASE=${DSYNC_DEST_BASE:-${3}}
 DSYNC_TREE_NAME=${DSYNC_TREE_NAME:-${4}}
@@ -39,7 +39,7 @@ if [[ -n $mpirun ]]; then
 	echo "Using mpirun: $mpirun $mpirun_opts"
 fi
 
-echo "Using dsync binary at: $DSYNC_TEST_BIN"
+echo "Using MFU binaries at: $MFU_TEST_BIN"
 echo "Using src parent directory at: $DSYNC_SRC_BASE"
 echo "Using dest parent directory at: $DSYNC_DEST_BASE"
 echo "Using test data from: $DSYNC_TREE_DATA"
@@ -93,9 +93,9 @@ function sync_and_verify()
 	fi
 
 	if [[ -n $mpirun ]]; then
-		$mpirun $mpirun_opts $DSYNC_TEST_BIN $quiet_opt $delete_opt $srcdir $destdir
+		$mpirun $mpirun_opts ${MFU_TEST_BIN}/dsync $quiet_opt $delete_opt $srcdir $destdir
 	else
-		$DSYNC_TEST_BIN $quiet_opt $delete_opt $srcdir $destdir
+		${MFU_TEST_BIN}/dsync $quiet_opt $delete_opt $srcdir $destdir
 	fi
 	rc=$?
 

--- a/test/tests/test_dsync/test_walkfail.sh
+++ b/test/tests/test_dsync/test_walkfail.sh
@@ -25,8 +25,6 @@ DSYNC_SRC_BASE=${DSYNC_SRC_BASE:-${2}}
 DSYNC_DEST_BASE=${DSYNC_DEST_BASE:-${3}}
 DSYNC_TREE_NAME=${DSYNC_TREE_NAME:-${4}}
 
-DSYNC_TREE_DATA=/usr/include/c++
-
 mpirun=$(which mpirun 2>/dev/null)
 mpirun_opts=""
 if [[ -n $mpirun ]]; then
@@ -42,7 +40,6 @@ fi
 echo "Using MFU binaries at: $MFU_TEST_BIN"
 echo "Using src parent directory at: $DSYNC_SRC_BASE"
 echo "Using dest parent directory at: $DSYNC_DEST_BASE"
-echo "Using test data from: $DSYNC_TREE_DATA"
 
 DSYNC_SRC_DIR=$(mktemp --directory ${DSYNC_SRC_BASE}/${DSYNC_TREE_NAME}.XXXXX)
 DSYNC_DEST_DIR=$(mktemp --directory ${DSYNC_DEST_BASE}/${DSYNC_TREE_NAME}.XXXXX)

--- a/test/tests/test_dsync/test_xattr.sh
+++ b/test/tests/test_dsync/test_xattr.sh
@@ -10,12 +10,12 @@
 # Turn on verbose output
 #set -x
 
-DSYNC_TEST_BIN=${DSYNC_TEST_BIN:-${1}}
+MFU_TEST_BIN=${MFU_TEST_BIN:-${1}}
 DSYNC_SRC_DIR=${DSYNC_SRC_DIR:-${2}}
 DSYNC_DEST_DIR=${DSYNC_DEST_DIR:-${3}}
 DSYNC_TMP_FILE=${DSYNC_TMP_FILE:-${4}}
 
-echo "Using dsync binary at: $DSYNC_TEST_BIN"
+echo "Using MFU binaries at: $MFU_TEST_BIN"
 echo "Using src directory at: $DSYNC_SRC_DIR"
 echo "Using dest directory at: $DSYNC_DEST_DIR"
 echo "Using temp file name: $DSYNC_TMP_FILE"
@@ -101,7 +101,7 @@ function sync_and_verify()
 		xattropt="--xattrs=$opt"
 	fi
 
-	$DSYNC_TEST_BIN --quiet $xattropt $srcdir $destdir
+	${MFU_TEST_BIN}/dsync --quiet $xattropt $srcdir $destdir
 
 	if [ $opt = "libattr" ]; then
 		sed --in-place "/^user.sync_and_verify_test/d" /etc/xattr.conf
@@ -152,7 +152,7 @@ set_other_xattrs $DSYNC_SRC_DIR/aaa
 
 # Make sure the short option is accepted; rest of tests use long option
 set -e
-$DSYNC_TEST_BIN --quiet -X all $DSYNC_SRC_DIR $DSYNC_DEST_DIR
+${MFU_TEST_BIN}/dsync --quiet -X all $DSYNC_SRC_DIR $DSYNC_DEST_DIR
 set +e
 
 # Sync and verify


### PR DESCRIPTION
Instead of using /usr/include/c++ as a source of test data, generate test data using dfilemaker.  There's no guarantee a machine being used for testing MFU will have /usr/include/c++ installed.

Remove TEST_TREE_DATA for test that does not use it.

Make first arg of the test_dsync tests, specify the MFU binary directory to use for testing, instead of specifying the path to dsync itself.