### PR TITLE
dsync: fix -L,--dereference option ignored

### DIFF
--- a/src/dsync/dsync.c
+++ b/src/dsync/dsync.c
@@ -3171,6 +3171,7 @@ int main(int argc, char **argv)
             copy_opts->dereference = 1;
             walk_opts->dereference = 1;
             copy_opts->no_dereference = 0;
+            break;
         case 'P':
             /* turn on no_dereference.
              * turn off dereference */


### PR DESCRIPTION
This commit fixes dsync ignoring -L,--dereference option because of a missing break in the case statement, causing walk/copy options to be overwritten by -P,--no-dereference values.