### PR TITLE
Fixing the build distribution for the tar file

### DIFF
--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -280,6 +280,7 @@ LIST(APPEND libmfu_srcs
   mpifileutils/src/common/mfu_bz2_static.c
   mpifileutils/src/common/mfu_compress_bz2_libcircle.c
   mpifileutils/src/common/mfu_decompress_bz2_libcircle.c
+  mpifileutils/src/common/mfu_proc.c
   mpifileutils/src/common/mfu_flist.c
   mpifileutils/src/common/mfu_flist_chunk.c
   mpifileutils/src/common/mfu_flist_copy.c

--- a/dist/builddist
+++ b/dist/builddist
@@ -23,7 +23,7 @@ if [ "$1" == "main" ] ; then
         "libcircle"    "hpc"  "master"
         "mpifileutils" "hpc"  "master"
     )
-elif [ "$1" == "v0.11.1" ] ; then
+elif [ "$1" == "v0.12" ] ; then
     # to build from latest branch of all repos
     ORGS=(
         "lwgrp"        "llnl" "v1.0.6"


### PR DESCRIPTION
Added mfu_proc.c to libmfu as it is now used across all tools
Fixed the builddist script by putting the right current version tag