### PR TITLE
DRAFT: ignore FS_IOC_FIEMAP failure with ENOTSUPP

### DIFF
--- a/src/common/mfu_errors.h
+++ b/src/common/mfu_errors.h
@@ -20,6 +20,10 @@ static inline int mfu_errno2rc(int err)
     return -1;
 }
 
+/* Non-standard error code returned by syscalls or external libs */
+/* Returned by ioctl(FIEMAP) with Lustre 2.15.6, should be 95 ENOTSUP */
+#define MFU_ERR_ENOTSUPP 524
+
 /* Generic error codes */
 #define MFU_ERR           1000
 #define MFU_ERR_INVAL_ARG 1001

--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -57,6 +57,7 @@
 
 #include "mfu.h"
 #include "mfu_flist_internal.h"
+#include "mfu_errors.h"
 #include "strmap.h"
 
 #ifdef LUSTRE_SUPPORT
@@ -1933,8 +1934,9 @@ static int mfu_copy_file_fiemap(
     }
 
     if (ioctl(mfu_src_file->fd, FS_IOC_FIEMAP, fiemap) < 0) {
-        if (errno == ENOTSUP) {
-            /* silently ignore */
+        if (errno == ENOTSUP || errno == MFU_ERR_ENOTSUPP) {
+            MFU_LOG(MFU_LOG_INFO, "Destination file not sparse; FIEMAP not supported for src '%s'",
+                    src, errno, strerror(errno));
         } else {
             MFU_LOG(MFU_LOG_ERR, "fiemap ioctl() failed for src '%s' (errno=%d %s)",
                     src, errno, strerror(errno));


### PR DESCRIPTION
Lustre can return ENOTSUPP (524) in response to an FS_IOC_FIEMAP ioctl() call, for a file striped a certain way.

The file can still be copied, fiemap just can't tell us where the holes are.

A brief survey using google searches suggests ENOTSUPP (524) was historically intended for use internal to the kernel or drivers, but has occasionally been returned to users by different software, in ways that have meaning similar to ENOTSUP.

Ignore the error as with ENOTSUP (95) so the file is copied without the use of fiemap.

Fixes #644