### PR TITLE
Add a --print0 option to print null terminated strings

### DIFF
--- a/src/dfind/dfind.c
+++ b/src/dfind/dfind.c
@@ -150,7 +150,7 @@ int MFU_PRED_PRINT (mfu_flist flist, uint64_t idx, void* arg)
 int MFU_PRED_PRINT0 (mfu_flist flist, uint64_t idx, void* arg)
 {
     const char* name = mfu_flist_file_get_name(flist, idx);
-    printf("%s\0", name);
+    printf("%s%c", name, '\0');
     return 1;
 }
 

--- a/src/dfind/dfind.c
+++ b/src/dfind/dfind.c
@@ -22,6 +22,7 @@
 
 int MFU_PRED_EXEC  (mfu_flist flist, uint64_t idx, void* arg);
 int MFU_PRED_PRINT (mfu_flist flist, uint64_t idx, void* arg);
+int MFU_PRED_PRINT0 (mfu_flist flist, uint64_t idx, void* arg);
 
 int MFU_PRED_EXEC (mfu_flist flist, uint64_t idx, void* arg)
 {
@@ -146,6 +147,13 @@ int MFU_PRED_PRINT (mfu_flist flist, uint64_t idx, void* arg)
     return 1;
 }
 
+int MFU_PRED_PRINT0 (mfu_flist flist, uint64_t idx, void* arg)
+{
+    const char* name = mfu_flist_file_get_name(flist, idx);
+    printf("%s\0", name);
+    return 1;
+}
+
 static void print_usage(void)
 {
     printf("\n");
@@ -191,6 +199,7 @@ static void print_usage(void)
     printf("\n");
     printf("Actions:\n");
     printf("  --print        - print item name to stdout\n");
+    printf("  --print0       - print item name to stdout with null terminator\n");
     printf("  --exec CMD ;   - execute CMD on item\n");
     printf("\n");
     fflush(stdout);
@@ -347,6 +356,7 @@ int main (int argc, char** argv)
         { "type",     required_argument, NULL, 'T' },
 
         { "print",    no_argument,       NULL, 'p' },
+        { "print0",    no_argument,       NULL, '0' },
         { "exec",     required_argument, NULL, 'e' },
         { NULL, 0, NULL, 0 },
     };
@@ -524,6 +534,10 @@ int main (int argc, char** argv)
     	case 'p':
     	    mfu_pred_add(pred_head, MFU_PRED_PRINT, NULL);
     	    break;
+
+        case '0':
+            mfu_pred_add(pred_head, MFU_PRED_PRINT0, NULL);
+            break;
 
     	case 'T':
             ret = add_type(pred_head, *optarg);


### PR DESCRIPTION
This option is useful for working with files that have special characters like newlines embedded in them.  It makes it it possible to pass this output to other downstream commands that can process null terminated strings, e.g. "parallel --null ..."

Added option string, new function MFU_PRED_PRINT0() and argument parsing to select this feature.