### PR TITLE
Draft: Add dfind "--printf FMT" option

### DIFF
--- a/src/common/mfu_flist.c
+++ b/src/common/mfu_flist.c
@@ -178,6 +178,7 @@ static size_t list_elem_pack2(void* buf, int detail, uint64_t chars, const elem_
         mfu_pack_uint64(&ptr, elem->ctime);
         mfu_pack_uint64(&ptr, elem->ctime_nsec);
         mfu_pack_uint64(&ptr, elem->size);
+        mfu_pack_uint64(&ptr, elem->blocks);
     }
     else {
         /* just have the file type */
@@ -233,6 +234,7 @@ static size_t list_elem_unpack2(const void* buf, elem_t* elem)
         mfu_unpack_uint64(&ptr, &elem->ctime);
         mfu_unpack_uint64(&ptr, &elem->ctime_nsec);
         mfu_unpack_uint64(&ptr, &elem->size);
+        mfu_unpack_uint64(&ptr, &elem->blocks);
         /* use mode to set file type */
         elem->type = mfu_flist_mode_to_filetype((mode_t)elem->mode);
     }
@@ -346,6 +348,7 @@ static void list_insert_copy(flist_t* flist, elem_t* src)
     elem->ctime      = src->ctime;
     elem->ctime_nsec = src->ctime_nsec;
     elem->size       = src->size;
+    elem->blocks     = src->blocks;
 
     /* append element to tail of linked list */
     mfu_flist_insert_elem(flist, elem);
@@ -388,7 +391,8 @@ void mfu_flist_insert_stat(flist_t* flist, const char* fpath, mode_t mode, const
         elem->ctime      = secs;
         elem->ctime_nsec = nsecs;
 
-        elem->size  = (uint64_t) sb->st_size;
+        elem->size    = (uint64_t) sb->st_size;
+        elem->blocks  = (uint64_t) sb->st_blocks;
 
         /* TODO: link to user and group names? */
     }
@@ -987,6 +991,17 @@ uint64_t mfu_flist_file_get_size(mfu_flist bflist, uint64_t idx)
     return ret;
 }
 
+uint64_t mfu_flist_file_get_blocks(mfu_flist bflist, uint64_t idx)
+{
+    uint64_t ret = (uint64_t) - 1;
+    flist_t* flist = (flist_t*) bflist;
+    elem_t* elem = list_get_elem(flist, idx);
+    if (elem != NULL && flist->detail) {
+        ret = elem->blocks;
+    }
+    return ret;
+}
+
 const char* mfu_flist_file_get_username(mfu_flist bflist, uint64_t idx)
 {
     const char* ret = NULL;
@@ -1167,6 +1182,16 @@ void mfu_flist_file_set_size(mfu_flist bflist, uint64_t idx, uint64_t size)
     elem_t* elem = list_get_elem(flist, idx);
     if (elem != NULL) {
         elem->size = size;
+    }
+    return;
+}
+
+void mfu_flist_file_set_blocks(mfu_flist bflist, uint64_t idx, uint64_t blocks)
+{
+    flist_t* flist = (flist_t*) bflist;
+    elem_t* elem = list_get_elem(flist, idx);
+    if (elem != NULL) {
+        elem->blocks = blocks;
     }
     return;
 }
@@ -1353,6 +1378,7 @@ uint64_t mfu_flist_file_create(mfu_flist bflist)
     elem->ctime      = 0;
     elem->ctime_nsec = 0;
     elem->size       = 0;
+    elem->blocks     = 0;
 
     /* for DAOS */
 #ifdef DAOS_SUPPORT

--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -395,6 +395,7 @@ uint64_t mfu_flist_file_get_mtime_nsec(mfu_flist flist, uint64_t index);
 uint64_t mfu_flist_file_get_ctime(mfu_flist flist, uint64_t index);
 uint64_t mfu_flist_file_get_ctime_nsec(mfu_flist flist, uint64_t index);
 uint64_t mfu_flist_file_get_size(mfu_flist flist, uint64_t index);
+uint64_t mfu_flist_file_get_blocks(mfu_flist flist, uint64_t index);
 uint64_t mfu_flist_file_get_perm(mfu_flist flist, uint64_t index);
 #if DCOPY_USE_XATTRS
 void *mfu_flist_file_get_acl(mfu_flist bflist, uint64_t idx, ssize_t *acl_size, char *type);

--- a/src/common/mfu_flist_internal.h
+++ b/src/common/mfu_flist_internal.h
@@ -40,6 +40,7 @@ typedef struct list_elem {
     uint64_t ctime;         /* create time */
     uint64_t ctime_nsec;    /* create time nanoseconds */
     uint64_t size;          /* file size in bytes */
+    uint64_t blocks;        /* number of 512B blocks allocated */
     struct list_elem* next; /* pointer to next item */
     /* vars for a non-posix DAOS copy */
     uint64_t obj_id_lo;

--- a/src/dfind/dfind.c
+++ b/src/dfind/dfind.c
@@ -22,6 +22,7 @@
 
 int MFU_PRED_EXEC  (mfu_flist flist, uint64_t idx, void* arg);
 int MFU_PRED_PRINT (mfu_flist flist, uint64_t idx, void* arg);
+int MFU_PRED_PRINTF (mfu_flist flist, uint64_t idx, void* arg);
 
 int MFU_PRED_EXEC (mfu_flist flist, uint64_t idx, void* arg)
 {
@@ -146,6 +147,55 @@ int MFU_PRED_PRINT (mfu_flist flist, uint64_t idx, void* arg)
     return 1;
 }
 
+void do_print_fn(mfu_flist flist, uint64_t idx, char spec)
+{
+    char* name;
+    uint64_t blocks;
+    uint64_t size;
+
+    switch (spec) {
+        case 'b':
+            blocks = mfu_flist_file_get_blocks(flist, idx);
+            printf("%llu", blocks);
+            break;
+        case 'p':
+            name = mfu_flist_file_get_name(flist, idx);
+            printf("%s", name);
+            break;
+        case 's':
+            size = mfu_flist_file_get_size(flist, idx);
+            printf("%llu", size);
+            break;
+        default:
+            printf("UNSUPPORTED FORMAT SPEC '%c'", spec);
+    }
+}
+
+int MFU_PRED_PRINTF (mfu_flist flist, uint64_t idx, void* arg)
+{
+    char *ptr = (char *) arg;
+
+    while (*ptr) {
+        if (*ptr == '%') {
+            ptr++;
+            if (*ptr == '\0')
+                break;
+            else if (*ptr == '%')
+                continue;
+            else {
+                do_print_fn(flist, idx, *ptr);
+                ptr++;
+            }
+        } else {
+            putc(*ptr, stdout);
+            ptr++;
+        }
+    }
+    printf("\n");
+
+    return 1;
+}
+
 static void print_usage(void)
 {
     printf("\n");
@@ -191,7 +241,13 @@ static void print_usage(void)
     printf("\n");
     printf("Actions:\n");
     printf("  --print        - print item name to stdout\n");
+    printf("  --printf FMT   - print to stdout for each item based on printf-style format\n");
     printf("  --exec CMD ;   - execute CMD on item\n");
+    printf("\n");
+    printf("Supported format string specifiers:\n");
+    printf("  %b             allocated space in 512-byte blocks\n");
+    printf("  %p             path name of file\n");
+    printf("  %s             size of file in bytes\n");
     printf("\n");
     fflush(stdout);
     return;
@@ -347,6 +403,7 @@ int main (int argc, char** argv)
         { "type",     required_argument, NULL, 'T' },
 
         { "print",    no_argument,       NULL, 'p' },
+        { "printf",   required_argument, NULL, 'f' },
         { "exec",     required_argument, NULL, 'e' },
         { NULL, 0, NULL, 0 },
     };
@@ -420,6 +477,12 @@ int main (int argc, char** argv)
 
     	case 'd':
     	    options.maxdepth = atoi(optarg);
+    	    break;
+
+    	case 'f':
+            /* TODO: error check argument */
+    	    buf = MFU_STRDUP(optarg);
+    	    mfu_pred_add(pred_head, MFU_PRED_PRINTF, (void *)buf);
     	    break;
 
     	case 'g':


### PR DESCRIPTION
Add a --printf option to dfind, enabling the user to produce strings with an arbitrary format using values discovered during the find (e.g. filename, file size, blocks allocated).  For example:

```
$ srun -N1 -n16 /g/g0/faaland1/projects/mfu-install/bin/^Cind --printf "%p blocks %b size %s"  /p/lflood/faaland1/swl/callan-toss4/
[2025-07-31T18:35:46] Walking /p/lflood/faaland1/swl/callan-toss4
[2025-07-31T18:35:56] Walked 486036 items in 10.004 secs (48582.588 items/sec) ...
[2025-07-31T18:36:02] Walked 765358 items in 15.729 secs (48658.632 items/sec) ...
[2025-07-31T18:36:02] Walked 765358 items in 15.731 seconds (48652.838 items/sec)
/p/lflood/faaland1/swl/callan-toss4/4.8-14rc0-pass1 blocks 260 size 133120
/p/lflood/faaland1/swl/callan-toss4/4.8-14rc0-pass1/sphot_998.stdout blocks 66 size 58056
/p/lflood/faaland1/swl/callan-toss4/4.8-14rc0-pass1/minimd_667.stderr blocks 66 size 1647
/p/lflood/faaland1/swl/callan-toss4/4.8-14rc0-pass1/pynamic_1042 blocks 52 size 26624
```