### PR TITLE
Add a -V,--batch_volume to group files by total volume.

### DIFF
--- a/doc/rst/dsync.1.rst
+++ b/doc/rst/dsync.1.rst
@@ -29,6 +29,11 @@ OPTIONS
 
    Batch files into groups of up to size N during copy operation.
 
+.. option:: -V, --batch-volume <SIZE>
+
+   Batch files into groups of up to volume <SIZE> during copy operation.
+   Units like "MB" and "GB" may immediately follow the number without spaces (e.g. 8MB)
+
 .. option:: --bufsize SIZE
 
    Set the I/O buffer to be SIZE bytes.  Units like "MB" and "GB" may

--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -2721,9 +2721,10 @@ int mfu_flist_copy(
         rc = -1;
     }
 
-    /* operate on files in batches if batch size is given */
+    /* operate on files in batches if batch size or volume is given */
     uint64_t batch_size = copy_opts->batch_files;
-    if (batch_size > 0) {
+    uint64_t batch_volume = copy_opts->batch_volume;
+    if (batch_size > 0 || batch_volume > 0) {
         /* operate in batches, get total size of list, our global
          * offset within it, and the local size of our list to
          * compute which batch our files are part of */
@@ -2739,7 +2740,8 @@ int mfu_flist_copy(
 
             /* copy a full batch or until we run out of files */
             uint64_t count = 0;
-            while (count < batch_size && (batch_offset + count) < src_size) {
+            uint64_t volume = 0;
+            while (count < batch_size && volume < batch_volume && (batch_offset + count) < src_size) {
                 /* compute global index of this file */
                 uint64_t global_idx = batch_offset + count;
 
@@ -2752,6 +2754,7 @@ int mfu_flist_copy(
                     mfu_filetype type = mfu_flist_file_get_type(src_cp_list, idx);
                     if (type != MFU_TYPE_DIR) {
                         mfu_flist_file_copy(src_cp_list, idx, tmplist);
+                        volume += mfu_flist_file_get_size(src_cp_list, idx);
                     }
                 }
 
@@ -3587,6 +3590,7 @@ mfu_copy_opts_t* mfu_copy_opts_new(void)
 
     /* By default, do not limit the batch size */
     opts->batch_files = 0;
+    opts->batch_volume = 0;
 
     return opts;
 }

--- a/src/common/mfu_param_path.h
+++ b/src/common/mfu_param_path.h
@@ -144,6 +144,7 @@ typedef struct {
     char*        block_buf2;       /* another buffer to read / write data */
     int          grouplock_id;     /* Lustre grouplock ID */
     uint64_t     batch_files;      /* max batch size to copy files, 0 implies no limit */
+    uint64_t     batch_volume;     /* max batch volume to copy files, 0 implies no limit */
 } mfu_copy_opts_t;
 
 /*

--- a/src/dsync/dsync.c
+++ b/src/dsync/dsync.c
@@ -62,26 +62,27 @@ static void print_usage(void)
     printf("       daos://<pool>/<cont>[/<path>] | <UNS path>\n");
 #endif
     printf("Options:\n");
-    printf("      --dryrun            - show differences, but do not synchronize files\n");
-    printf("  -b  --batch-files <N>   - batch files into groups of N during copy\n");
-    printf("      --bufsize <SIZE>    - IO buffer size in bytes (default " MFU_BUFFER_SIZE_STR ")\n");
-    printf("      --chunksize <SIZE>  - minimum work size per task in bytes (default " MFU_CHUNK_SIZE_STR ")\n");
-    printf("  -X, --xattrs <OPT>      - copy xattrs (none, all, non-lustre, libattr)\n");
+    printf("      --dryrun              - show differences, but do not synchronize files\n");
+    printf("  -b  --batch-files <N>     - batch files into groups of N during copy\n");
+    printf("  -V  --batch-volume <SIZE> - batch files into groups of SIZE during copy\n");
+    printf("      --bufsize <SIZE>      - IO buffer size in bytes (default " MFU_BUFFER_SIZE_STR ")\n");
+    printf("      --chunksize <SIZE>    - minimum work size per task in bytes (default " MFU_CHUNK_SIZE_STR ")\n");
+    printf("  -X, --xattrs <OPT>        - copy xattrs (none, all, non-lustre, libattr)\n");
 #ifdef DAOS_SUPPORT
-    printf("      --daos-api          - DAOS API in {DFS, DAOS} (default uses DFS for POSIX containers)\n");
+    printf("      --daos-api            - DAOS API in {DFS, DAOS} (default uses DFS for POSIX containers)\n");
 #endif
-    printf("  -c, --contents          - read and compare file contents rather than compare size and mtime\n");
-    printf("  -D, --delete            - delete extraneous files from target\n");
-    printf("  -L, --dereference       - copy original files instead of links\n");
-    printf("  -P, --no-dereference    - don't follow links in source\n"); 
-    printf("  -s, --direct            - open files with O_DIRECT\n");
-    printf("      --open-noatime      - open files with O_NOATIME\n");
-    printf("      --link-dest <DIR>   - hardlink to files in DIR when unchanged\n");
-    printf("  -S, --sparse            - create sparse files when possible\n");
-    printf("      --progress <N>      - print progress every N seconds\n");
-    printf("  -v, --verbose           - verbose output\n");
-    printf("  -q, --quiet             - quiet output\n");
-    printf("  -h, --help              - print usage\n");
+    printf("  -c, --contents            - read and compare file contents rather than compare size and mtime\n");
+    printf("  -D, --delete              - delete extraneous files from target\n");
+    printf("  -L, --dereference         - copy original files instead of links\n");
+    printf("  -P, --no-dereference      - don't follow links in source\n"); 
+    printf("  -s, --direct              - open files with O_DIRECT\n");
+    printf("      --open-noatime        - open files with O_NOATIME\n");
+    printf("      --link-dest <DIR>     - hardlink to files in DIR when unchanged\n");
+    printf("  -S, --sparse              - create sparse files when possible\n");
+    printf("      --progress <N>        - print progress every N seconds\n");
+    printf("  -v, --verbose             - verbose output\n");
+    printf("  -q, --quiet               - quiet output\n");
+    printf("  -h, --help                - print usage\n");
     printf("\n");
     printf("For more information see https://mpifileutils.readthedocs.io.\n");
     fflush(stdout);
@@ -3105,7 +3106,7 @@ int main(int argc, char **argv)
 
     while (1) {
         int c = getopt_long(
-            argc, argv, "b:cDso:LPSvqhX:",
+            argc, argv, "b:V:cDso:LPSvqhX:",
             long_options, &option_index
         );
 
@@ -3116,6 +3117,17 @@ int main(int argc, char **argv)
         switch (c) {
         case 'b':
             copy_opts->batch_files = atoi(optarg);
+            break;
+        case 'V':
+            if (mfu_abtoull(optarg, &bytes) != MFU_SUCCESS || bytes == 0) {
+                if (rank == 0) {
+                    MFU_LOG(MFU_LOG_ERR,
+                            "Failed to parse volume size: '%s'", optarg);
+                }
+                usage = 1;
+            } else {
+                copy_opts->batch_volume = bytes;
+            }
             break;
         case 'B':
             if (mfu_abtoull(optarg, &bytes) != MFU_SUCCESS || bytes == 0) {


### PR DESCRIPTION
Just like -b,--batch-files, -V,--batch_volume <SIZE> will batch files into groups of up to volume <SIZE>, whatever comes first between --batch-files and --batch-volume predicates.

It could help https://github.com/hpc/mpifileutils/issues/645. That's not a bulletproof solution against all cases, but this could certainly help with long trail situation as in https://github.com/hpc/mpifileutils/issues/645.