### PR TITLE
Portability fixes: guard Linux-only APIs for FreeBSD/non-Linux builds

### DIFF
--- a/src/common/mfu_bz2.c
+++ b/src/common/mfu_bz2.c
@@ -5,13 +5,14 @@
 #include <string.h>
 #include <errno.h>
 
-/* for statfs */
-#include <sys/vfs.h>
+#if defined(__linux__)
+#include <sys/vfs.h>  /* for statfs */
+#endif
 
+#if defined(__linux__) && LUSTRE_SUPPORT
 /* for LL_SUPER_MAGIC */
-#if LUSTRE_SUPPORT
 #include <lustre/lustre_user.h>
-#endif /* LUSTRE_SUPPORT */
+#endif /* __linux__ && LUSTRE_SUPPORT */
 
 #include "mpi.h"
 #include "mfu.h"

--- a/src/common/mfu_bz2.h
+++ b/src/common/mfu_bz2.h
@@ -1,6 +1,7 @@
 #ifndef MFU_BZ2_H
 #define MFU_BZ2_H
 
+int mfu_compress_bz2_static(const char* src_name, const char* dst_name, int b_size);
 int mfu_compress_bz2(const char* src_name, const char* dst_name, int b_size);
 int mfu_decompress_bz2(const char* src_name, const char* dst_name);
 

--- a/src/common/mfu_bz2_static.c
+++ b/src/common/mfu_bz2_static.c
@@ -5,7 +5,9 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(__linux__)
 #include <sys/sysinfo.h>
+#endif
 #include <string.h>
 #include <sys/time.h>
 #include <sys/resource.h>
@@ -22,6 +24,10 @@
 #include "libcircle.h"
 #include "mfu.h"
 #include "mfu_bz2.h"
+
+#ifndef O_LARGEFILE
+#define O_LARGEFILE 0
+#endif
 
 #define FILE_MODE (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)
 

--- a/src/common/mfu_compress_bz2_libcircle.c
+++ b/src/common/mfu_compress_bz2_libcircle.c
@@ -5,7 +5,9 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(__linux__)
 #include <sys/sysinfo.h>
+#endif
 #include <string.h>
 #include <sys/time.h>
 #include <sys/resource.h>
@@ -23,6 +25,7 @@
 #include "mfu.h"
 #include "mfu_bz2.h"
 
+#if defined(__linux__)
 #define FILE_MODE (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)
 
 struct block_info {
@@ -531,3 +534,11 @@ int mfu_compress_bz2_libcircle(const char* src, const char* dst, int b_size, ssi
 
     return rc;
 }
+#else
+int mfu_compress_bz2_libcircle(const char* src, const char* dst,
+                                int b_size, ssize_t opts_memory)
+{
+    (void)opts_memory;
+    return mfu_compress_bz2_static(src, dst, b_size);
+}
+#endif

--- a/src/common/mfu_decompress_bz2_libcircle.c
+++ b/src/common/mfu_decompress_bz2_libcircle.c
@@ -5,7 +5,9 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(__linux__)
 #include <sys/sysinfo.h>
+#endif
 #include <string.h>
 #include <sys/time.h>
 #include <sys/resource.h>

--- a/src/common/mfu_flist.c
+++ b/src/common/mfu_flist.c
@@ -12,6 +12,9 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#if !defined(__linux__)
+#undef DCOPY_USE_XATTRS
+#endif
 #include <string.h>
 #include <unistd.h>
 #include <getopt.h>
@@ -35,8 +38,10 @@
 #include <sys/ioctl.h>
 #include <sys/param.h>
 
+#ifdef __linux__
 #include <linux/fs.h>
 #include <linux/fiemap.h>
+#endif
 
 #include <libgen.h> /* dirname */
 #include "libcircle.h"

--- a/src/common/mfu_flist.h
+++ b/src/common/mfu_flist.h
@@ -44,7 +44,7 @@ extern "C" {
 #include <stdbool.h>
 #include "mpi.h"
 
-#if DCOPY_USE_XATTRS
+#if defined(__linux__) && DCOPY_USE_XATTRS
 #include <sys/xattr.h>
 /*
  * Newer versions of attr deprecated attr/xattr.h which defines ENOATTR as a

--- a/src/common/mfu_flist_archive.c
+++ b/src/common/mfu_flist_archive.c
@@ -40,6 +40,14 @@
 #include <lustre/lustreapi.h>
 #endif
 
+#ifndef O_NOATIME
+#define O_NOATIME 0
+#endif
+
+#ifndef O_LARGEFILE
+#define O_LARGEFILE 0
+#endif
+
 /* for magic value we use "DTAR_IDX" in ASCII (8-bit) */
 #define DTAR_MAGIC (0x445441525F494458)
 
@@ -5265,7 +5273,12 @@ static int extract_xattrs(
                 r = archive_entry_xattr_next(entry, &xname, &xval, &xsize);
                 if (r == ARCHIVE_OK) {
                     /* successfully extracted xattr, now try to set it */
+#ifdef __linux__
                     int set_rc = setxattr(path, xname, xval, xsize, 0);
+#else
+                    int set_rc = -1;
+                    errno = ENOTSUP;
+#endif
                     if (set_rc == -1) {
                         MFU_LOG(MFU_LOG_ERR, "failed to setxattr '%s' on '%s' errno=%d %s",
                             xname, path, errno, strerror(errno) 

--- a/src/common/mfu_flist_copy.c
+++ b/src/common/mfu_flist_copy.c
@@ -39,8 +39,15 @@
 #include <sys/ioctl.h>
 #include <sys/param.h>
 
+#ifdef __linux__
 #include <linux/fs.h>
 #include <linux/fiemap.h>
+typedef __u64 mfu_u64;
+typedef __u32 mfu_u32;
+#else
+typedef uint64_t mfu_u64;
+typedef uint32_t mfu_u32;
+#endif
 
 /* define PRI64 */
 #include <inttypes.h>
@@ -72,6 +79,10 @@
 #include <linux/hpssfs.h>
 #endif
 
+#ifndef O_NOATIME
+#define O_NOATIME 0
+#endif
+
 /****************************************
  * Define types
  ***************************************/
@@ -98,6 +109,47 @@ typedef struct {
     dfs_obj_t* obj; /* open object */
 #endif
 } mfu_copy_file_cache_t;
+
+#if DCOPY_USE_XATTRS && !defined(__linux__)
+
+#include <errno.h>
+#include <sys/types.h>
+
+static inline ssize_t
+llistxattr(const char *path, char *list, size_t size)
+{
+    (void)path;
+    (void)list;
+    (void)size;
+    errno = ENOTSUP;
+    return -1;
+}
+
+static inline ssize_t
+lgetxattr(const char *path, const char *name, void *value, size_t size)
+{
+    (void)path;
+    (void)name;
+    (void)value;
+    (void)size;
+    errno = ENOTSUP;
+    return -1;
+}
+
+static inline int
+lsetxattr(const char *path, const char *name,
+          const void *value, size_t size, int flags)
+{
+    (void)path;
+    (void)name;
+    (void)value;
+    (void)size;
+    (void)flags;
+    errno = ENOTSUP;
+    return -1;
+}
+
+#endif
 
 /****************************************
  * Define globals
@@ -1889,13 +1941,13 @@ static int mfu_copy_file_normal(
 }
 
 struct mfu_extent {
-    __u64 me_logical;  /* logical offset in bytes for the start of the extent */
-    __u64 me_length;   /* length in bytes for this extent */
+    mfu_u64 me_logical;  /* logical offset in bytes for the start of the extent */
+    mfu_u64 me_length;   /* length in bytes for this extent */
 };
 
 struct mfu_extent_list {
-    __u32 mel_mapped_extents;/* number of extents that were mapped */
-    __u32 mel_extent_count;  /* size of fm_extents array */
+    mfu_u32 mel_mapped_extents;/* number of extents that were mapped */
+    mfu_u32 mel_extent_count;  /* size of fm_extents array */
     struct mfu_extent mel_extents[0]; /* array of mapped extents */
 };
 
@@ -1926,6 +1978,7 @@ struct mfu_extent_list *mfu_extent_list_realloc(struct mfu_extent_list *orig, si
     return extent_list;
 }
 
+#ifdef __linux__
 static struct mfu_extent_list * mfu_fiemap_get_extents(
     const char* src,
     const char* dest,
@@ -2026,6 +2079,7 @@ fail_free_fiemap:
 fail_no_fiemap:
     return NULL;
 }
+#endif
 
 /*
  * if returned extent_list * is non-NULL, and normal_copy_required == false,
@@ -2175,6 +2229,7 @@ static int mfu_copy_file_extents(
             free(extent_list);
         }
 
+#ifdef __linux__
         /* extents acquired by fiemap ioctl */
         extent_list = mfu_fiemap_get_extents( src, dest,
             offset, length, file_size, normal_copy_required, copy_opts,
@@ -2183,6 +2238,9 @@ static int mfu_copy_file_extents(
         if (!extent_list || *normal_copy_required == true) {
             goto fail_fiemap;
         }
+#else
+        goto fail_normal_copy;
+#endif
     }
 
     /* seek to offset in source file */

--- a/src/common/mfu_flist_walk.c
+++ b/src/common/mfu_flist_walk.c
@@ -39,6 +39,10 @@
 #include "mfu_flist_internal.h"
 #include "strmap.h"
 
+#ifndef O_NOATIME
+#define O_NOATIME 0
+#endif
+
 /****************************************
  * Globals
  ***************************************/
@@ -205,7 +209,13 @@ static void walk_getdents_process_dir(const char* dir, CIRCLE_handle* handle)
     /* Read all directory entries */
     while (1) {
         /* execute system call to get block of directory entries */
-        int nread = syscall(SYS_getdents, mfu_file->fd, buf, (int) BUF_SIZE);
+        int nread;
+
+#ifdef __linux__
+        nread = syscall(SYS_getdents, mfu_file->fd, buf, (int)BUF_SIZE);
+#else
+        nread = getdents(mfu_file->fd, buf, (size_t)BUF_SIZE);
+#endif
         if (nread == -1) {
             MFU_LOG(MFU_LOG_ERR, "syscall to getdents failed when reading `%s' (errno=%d %s)", dir, errno, strerror(errno));
             WALK_RESULT = -1;
@@ -767,7 +777,7 @@ void mfu_flist_stat(
         /* check whether we should skip this item */
         if (skip_fn != NULL && skip_fn(name, skip_args)) {
             /* skip this file, don't include it in new list */
-            MFU_LOG(MFU_LOG_INFO, "skip %s");
+            MFU_LOG(MFU_LOG_INFO, "skip %s", name);
             continue;
         }
 

--- a/src/common/mfu_io.c
+++ b/src/common/mfu_io.c
@@ -21,6 +21,11 @@
 #include "mfu.h"
 #include "mfu_errors.h"
 
+#ifdef __FreeBSD__
+#undef lstat64
+#define lstat64(path, buf) lstat((path), (struct stat *)(buf))
+#endif
+
 #define MFU_IO_TRIES  (5)
 #define MFU_IO_USLEEP (100)
 

--- a/src/common/mfu_io.h
+++ b/src/common/mfu_io.h
@@ -42,6 +42,11 @@ extern "C" {
 
 #include "mfu_param_path.h"
 
+#ifdef __FreeBSD__
+#define stat64  stat
+#define lstat64 lstat
+#endif
+
 /* Intent is to wrap all POSIX I/O routines used by mfu tools.  May
  * abort on fatal conditions to avoid checking condition at every call.
  * May also automatically retry on things like EINTR. */

--- a/src/common/mfu_param_path.c
+++ b/src/common/mfu_param_path.c
@@ -1,5 +1,10 @@
 #define _GNU_SOURCE
 
+#if defined(__FreeBSD__)
+#include <sys/types.h>
+#include <sys/stat.h>
+#endif
+
 #include "mfu.h"
 #include "mpi.h"
 
@@ -522,7 +527,7 @@ void mfu_param_path_check_copy(uint64_t num, const mfu_param_path* paths,
                 /* dest is a file */
                 dest_is_file = true;
             }
-            else if(S_ISLNK(destpath->path_stat.st_mode)) {
+            else if (S_ISLNK(destpath->path_stat.st_mode)) {
                 /* dest is a symlink, but to what? */
                 if (destpath->target_stat_valid) {
                     /* target of the symlink exists, determine what it is */

--- a/src/common/mfu_util.c
+++ b/src/common/mfu_util.c
@@ -1,6 +1,11 @@
 /* to get nsec fields in stat structure */
 #define _GNU_SOURCE
 
+#if defined(__FreeBSD__)
+#include <sys/param.h>
+#include <sys/mount.h>
+#endif
+
 #include "mfu.h"
 #include "mpi.h"
 #include "dtcmp.h"
@@ -16,9 +21,22 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <fcntl.h>
 #include <unistd.h>
 
+#if defined(__linux__)
 #include <sys/vfs.h>
+#endif
+
+#ifndef POSIX_FADV_SEQUENTIAL
+#define POSIX_FADV_SEQUENTIAL 2
+#endif
+#ifndef O_NOATIME
+#define O_NOATIME 0
+#endif
+#ifndef O_DIRECT
+#define O_DIRECT 0
+#endif
 
 #ifndef ULLONG_MAX
 #define ULLONG_MAX (__LONG_LONG_MAX__ * 2UL + 1UL)
@@ -939,7 +957,7 @@ int mfu_compare_contents(
                 /* check for write error */
                 if (bytes_written < 0) {
                     MFU_LOG(MFU_LOG_ERR, "Failed to write `%s' at offset %llx (errno=%d %s)", 
-                        dst_name, (unsigned long long)off + n, strerror(errno));
+                        dst_name, (unsigned long long)off + n, errno, strerror(errno));
                     rc = -1;
                     break;
                 }

--- a/src/dbcast/dbcast.c
+++ b/src/dbcast/dbcast.c
@@ -16,7 +16,12 @@
 #include <string.h>
 #include <getopt.h>
 
+#ifdef __linux__
 #include <sys/vfs.h>
+#elif defined(__FreeBSD__)
+#include <sys/param.h>
+#include <sys/mount.h>
+#endif
 
 // mmap and friends for shared memory
 #include <sys/mman.h>
@@ -31,6 +36,14 @@
  * procs on the node read data from Lustre, send data to the writer,
  * and send data to each other.  The writer flow controls these worker
  * processes with messages. */
+
+#ifndef HOST_NAME_MAX
+#ifdef MAXHOSTNAMELEN
+#define HOST_NAME_MAX MAXHOSTNAMELEN
+#else
+#define HOST_NAME_MAX 256
+#endif
+#endif
 
 #define GCS_SUCCESS (0)
 
@@ -803,7 +816,7 @@ int main (int argc, char *argv[])
             /* check whether we have space to write the file */
             if (file_size > free_size) {
                 /* not enough space for file */
-                MFU_LOG(MFU_LOG_ERR, "Insufficient space for file `%s` filesize=%llu free=%llu", out_file_path, file_size, free_size);
+                MFU_LOG(MFU_LOG_ERR, "Insufficient space for file `%s` filesize=%llu free=%llu", out_file_path, (unsigned long long)file_size, (unsigned long long)free_size);
                 write_error = 1;
             }
         }
@@ -1118,14 +1131,14 @@ if (node_rank == 0) {
          * a file by the same name but of different size than a previous copy */
         errno = 0;
         if (mfu_truncate(out_file_path, (off_t) file_size) != 0) {
-            MFU_LOG(MFU_LOG_ERR, "Failed to truncate file `%s`", out_file_path, strerror(errno));
+            MFU_LOG(MFU_LOG_ERR, "Failed to truncate file `%s`: %s", out_file_path, strerror(errno));
             write_error = 1;
         }
 
         /* have every writer update file mode */
         errno = 0;
         if (mfu_chmod(out_file_path, (mode_t) mode) != 0) {
-            MFU_LOG(MFU_LOG_ERR, "Failed to chmod file `%s`", out_file_path, strerror(errno));
+            MFU_LOG(MFU_LOG_ERR, "Failed to chmod file `%s`: %s", out_file_path, strerror(errno));
             write_error = 1;
         }
 
@@ -1133,14 +1146,14 @@ if (node_rank == 0) {
         if (write_error) {
             errno = 0;
             if (mfu_unlink(out_file_path) != 0) {
-                MFU_LOG(MFU_LOG_ERR, "Failed to unlink file `%s`", out_file_path, strerror(errno));
+                MFU_LOG(MFU_LOG_ERR, "Failed to unlink file `%s`: %s", out_file_path, strerror(errno));
             }
         }
     } else {
         /* readers close input file */
         errno = 0;
         if (mfu_close(in_file_path, in_file) != 0) {
-            MFU_LOG(MFU_LOG_ERR, "Failed to close file `%s`", in_file_path, strerror(errno));
+            MFU_LOG(MFU_LOG_ERR, "Failed to close file `%s`: %s", in_file_path, strerror(errno));
         }
     }
 

--- a/src/dbz2/dbz2.c
+++ b/src/dbz2/dbz2.c
@@ -1,7 +1,9 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(__linux__)
 #include <sys/sysinfo.h>
+#endif
 #include <string.h>
 #include <sys/time.h>
 #include <sys/resource.h>

--- a/src/dcmp/dcmp.c
+++ b/src/dcmp/dcmp.c
@@ -4,7 +4,12 @@
 #include <stdlib.h>
 #include <mpi.h>
 #include <libcircle.h>
+#ifdef __linux__
 #include <linux/limits.h>
+#elif defined(__FreeBSD__)
+#include <limits.h>
+#include <sys/param.h>
+#endif
 #include <libgen.h>
 #include <errno.h>
 #include <dtcmp.h>

--- a/src/dcp1/cleanup.c
+++ b/src/dcp1/cleanup.c
@@ -51,8 +51,8 @@ static void DCOPY_truncate_file(DCOPY_operation_t* op, \
      * Try the recursive file before file-to-file. The cast below requires us
      * to have a maximum file_size of 2^63, not 2^64.
      */
-    if(truncate64(dest_path_recursive, op->file_size) < 0) {
-        if(truncate64(dest_path_file_to_file, op->file_size) < 0) {
+    if(mfu_truncate(dest_path_recursive, op->file_size) < 0) {
+        if(mfu_truncate(dest_path_file_to_file, op->file_size) < 0) {
             MFU_LOG(MFU_LOG_ERR, "Failed to truncate destination file: %s (errno=%d %s)",
                 dest_path_recursive, errno, strerror(errno));
 

--- a/src/dcp1/common.h
+++ b/src/dcp1/common.h
@@ -44,7 +44,7 @@
 #include <unistd.h>
 #include <utime.h>
 
-#if DCOPY_USE_XATTRS
+#if defined(__linux__) && DCOPY_USE_XATTRS
 #include <sys/xattr.h>
 /*
  * Newer versions of attr deprecated attr/xattr.h which defines ENOATTR as a

--- a/src/ddup/ddup.c
+++ b/src/ddup/ddup.c
@@ -13,6 +13,10 @@
 #include "mfu.h"
 #include "list.h"
 
+#ifndef O_NOATIME
+#define O_NOATIME 0
+#endif
+
 /* number of uint64_t values in our key
  * 1 for group ID + (SHA256_DIGEST_LENGTH / 8) */
 #define DDUP_KEY_SIZE 5

--- a/src/dsync/dsync.c
+++ b/src/dsync/dsync.c
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <mpi.h>
 #include <libcircle.h>
-#include <linux/limits.h>
+#include <limits.h>
 #include <libgen.h>
 #include <errno.h>
 #include <dtcmp.h>
@@ -32,6 +32,10 @@
 #define _XOPEN_SOURCE 600
 #include <fcntl.h>
 #include <string.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
 
 /* for bool type, true/false macros */
 #include <stdbool.h>


### PR DESCRIPTION
## Summary

mpifileutils currently assumes a Linux build environment throughout: it
includes Linux-specific kernel headers unconditionally, uses
`sysinfo(2)`, `truncate64()`, and `SYS_getdents` directly, and guards
xattr code only against the `DCOPY_USE_XATTRS` build flag rather than
platform availability.

This PR makes mpifileutils build on FreeBSD by guarding Linux-specific
headers and APIs behind `#ifdef __linux__` and providing small
compatibility shims where needed. All changes are intentionally minimal
— Linux behavior and all Linux-only fast paths (fiemap, xattr,
sysinfo-based compressor) remain completely unchanged.

### Background

These changes were developed while packaging mpifileutils for the
FreeBSD ports tree (`sysutils/mpifileutils`). The port landed in April
2026 (ports commit
[5f283cddd7b7](https://cgit.FreeBSD.org/ports/commit/?id=5f283cddd7b7c17cd59a5a887bf4ae74566ccbd1),
co-authored with Vladimir Druzenko / vvd@FreeBSD.org) and has been
carrying these as local patches since then. This PR upstreams them.

## What the patch actually does

### Linux-only kernel headers

`<linux/fs.h>`, `<linux/fiemap.h>`, `<linux/limits.h>`, and
`<sys/sysinfo.h>` do not exist on FreeBSD and cause hard build failures
if included unconditionally. Each is now guarded with `#ifdef __linux__`
and a portable alternative is provided where one exists:

- `<linux/limits.h>` → `<limits.h>` (POSIX) in `dcmp.c` and `dsync.c`
- `<sys/vfs.h>` → `<sys/param.h>` + `<sys/mount.h>` on FreeBSD in
  `mfu_bz2.c`, `mfu_util.c`, and `dbcast.c`

### sysinfo-dependent bz2 compressor

`mfu_compress_bz2_libcircle()` uses `sysinfo(2)` (Linux-only) to
determine available memory for wave sizing. On non-Linux, the entire
sysinfo/libcircle-dependent implementation is compiled out and the
function forwards to `mfu_compress_bz2_static()`, which is portable.
The decompressor side has no sysinfo dependency so only the header guard
is needed there.

### stat64 / lstat64

FreeBSD's libc provides only `stat`/`lstat`; 64-bit file sizes are
implicit. `mfu_io.h` and `mfu_io.c` map `stat64`/`lstat64` to their
non-suffixed equivalents under `#ifdef __FreeBSD__`.

### xattr support

xattr APIs differ between Linux and FreeBSD. Rather than attempting a
cross-platform xattr implementation, xattr support is simply disabled on
non-Linux:

- `mfu_flist.c` undefines `DCOPY_USE_XATTRS` on non-Linux before any
  xattr-dependent code is reached, so existing `#if DCOPY_USE_XATTRS`
  guards in the file continue to work correctly without modification.
- `mfu_flist.h` and `dcp1/common.h` gate `<sys/xattr.h>` on
  `defined(__linux__) && DCOPY_USE_XATTRS`.
- `mfu_flist_copy.c` adds `ENOTSUP`-returning stubs for
  `llistxattr`/`lgetxattr`/`lsetxattr` under
  `#if DCOPY_USE_XATTRS && !defined(__linux__)`, so `mfu_copy_xattrs()`
  degrades gracefully (it already handles `ENOTSUP`).

### fiemap sparse copy

`mfu_fiemap_get_extents()` and the fiemap ioctl copy path in
`mfu_copy_file_extents()` are gated on `#ifdef __linux__`. On non-Linux
the function falls through to the normal copy path via
`goto fail_normal_copy`.

### Directory walking

`walk_getdents_process_dir()` called the raw `SYS_getdents` syscall
directly. On FreeBSD the libc `getdents(2)` wrapper is used instead.

### Miscellaneous portability fixes

- `O_LARGEFILE` fallback macro (implicit on FreeBSD) in `mfu_bz2_static.c`
- `HOST_NAME_MAX` fallback in `dbcast.c` (FreeBSD uses `MAXHOSTNAMELEN`)
- `POSIX_FADV_SEQUENTIAL` fallback in `mfu_util.c`
- `PATH_MAX` fallback in `dsync.c`
- `truncate64()` → `mfu_truncate()` in `dcp1/cleanup.c`
- `<sys/types.h>` / `<sys/stat.h>` added to `mfu_param_path.c` for FreeBSD

### Incidental bug fixes found during porting

- `mfu_flist_walk.c`: `MFU_LOG(MFU_LOG_INFO, "skip %s")` missing `name`
  argument (format/argument mismatch, undefined behavior)
- `mfu_util.c`: `MFU_LOG` call passing `strerror(errno)` for a `%d`
  format specifier; `errno` argument was missing
- `dbcast.c`: three `MFU_LOG` calls with missing `%s` format specifiers
  or missing `(unsigned long long)` casts on `%llu` arguments

## Platform impact

- **Linux**: no behavioral change. All Linux-only fast paths remain
  enabled. The diff to existing Linux-compiled code is zero.
- **FreeBSD / non-Linux**: builds cleanly; fiemap sparse copy and Linux
  xattr preservation are disabled pending native implementations.

## Testing

- Built via FreeBSD ports tooling (`poudriere testport`, `stage-qa`,
  plist checks) on FreeBSD 14.3 and 15.0 amd64.
- Basic runtime smoke tests: `dcp`, `dcmp`, `dsync`, `dbcast`, `dbz2`
  on small test trees.

## Note on `#ifdef __linux__` vs cmake feature detection

I've used `#ifdef __linux__` rather than cmake `check_include_file()`
feature gates throughout, since the guarded headers (`<linux/fs.h>`,
`<sys/sysinfo.h>`, etc.) are Linux kernel interfaces with no
cross-platform equivalent — feature detection wouldn't make the intent
clearer. Happy to convert to cmake-style guards in a follow-up if
preferred.

## References

- FreeBSD ports PR: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=291679
- FreeBSD Differential: https://reviews.freebsd.org/D54230
- Ports tree commit: https://cgit.FreeBSD.org/ports/commit/?id=5f283cddd7b7c17cd59a5a887bf4ae74566ccbd1