### PR TITLE
Ensure error code is kept if destination dir is not writable

### DIFF
--- a/src/dsync/dsync.c
+++ b/src/dsync/dsync.c
@@ -3361,6 +3361,7 @@ int main(int argc, char **argv)
                 dest_parent_str, errno, strerror(errno));
         if (!options.dry_run) {
             mfu_free(&dest_parent_str);
+			rc = errno;
             goto ERROR;
         }
     }


### PR DESCRIPTION
This resolves #668. The error code was not being retained, so `rc` was stlil zero. I've added it in, keeping the `errno` value. 

```
$ bin/dsync -X all -q m.grib2 zzfsdfzz/a; echo $?
2
```