### PR TITLE
dwalk: accept file-histogram option alias

### DIFF
--- a/doc/rst/dwalk.1.rst
+++ b/doc/rst/dwalk.1.rst
@@ -54,7 +54,7 @@ OPTIONS
    bytes, between 1-80 bytes, between 81-99 bytes, and 100 bytes or
    greater.
 
-.. option:: -f, --file-histogram
+.. option:: -f, --file_histogram, --file-histogram
 
    Creates a file histogram without requiring the user to provide
    the bin sizes. The bins are created dynamically based on the

--- a/src/dwalk/dwalk.c
+++ b/src/dwalk/dwalk.c
@@ -317,7 +317,8 @@ static void print_usage(void)
     printf("  -l, --lite              - walk file system without stat\n");
     printf("  -s, --sort <fields>     - sort output by comma-delimited fields\n");
     printf("  -d, --distribution <field>:<separators> \n                          - print distribution by field\n");
-    printf("  -f, --file_histogram    - print default size distribution of items\n");
+    printf("  -f, --file_histogram, --file-histogram\n");
+    printf("                          - print default size distribution of items\n");
     printf("  -p, --print             - print files to screen\n");
     printf("      --no-atime          - use with -l; do not update the file last access time\n");
     printf("  -L, --dereference       - follow symbolic links\n");
@@ -390,6 +391,7 @@ int main(int argc, char** argv)
         {"sort",           1, 0, 's'},
         {"distribution",   1, 0, 'd'},
         {"file_histogram", 0, 0, 'f'},
+        {"file-histogram", 0, 0, 'f'},
         {"print",          0, 0, 'p'},
         {"no-atime",       0, 0, 'n'},
         {"dereference",    0, 0, 'L'},


### PR DESCRIPTION
## Description

Adds `--file-histogram` as an accepted alias for the existing `--file_histogram` dwalk option, and updates the usage text and man page to document both long option spellings.

This keeps the existing underscore form working while allowing the hyphenated form shown in the man page.

## Related Issues

Resolves #678

## Validation

- Ran `git diff --check`
- Verified the getopt long option table maps both aliases to `-f`

## AI Assistance

This PR was authored with assistance from AI.