### PR TITLE
CMakeLists.txt: Add missing mfu_proc header

### DIFF
--- a/dist/CMakeLists.txt
+++ b/dist/CMakeLists.txt
@@ -263,6 +263,7 @@ LIST(APPEND libmfu_install_headers
   mpifileutils/src/common/mfu_param_path.h
   mpifileutils/src/common/mfu_path.h
   mpifileutils/src/common/mfu_pred.h
+  mpifileutils/src/common/mfu_proc.h
   mpifileutils/src/common/mfu_progress.h
   mpifileutils/src/common/mfu_util.h
   )


### PR DESCRIPTION
Hi,

Before this patch, trying to include mfu.h in a source program fails:

```
$ cat test_mpfu.c
#include "mfu_proc.h"
int main(){
	return 0;
}
$ cc -I/usr/include/openmpi-x86_64 test_mpfu.c -o test_mpfu
In file included from test_mpfu.c:1:
/usr/include/mfu.h:30:10: erreur fatale: mfu_proc.h : Aucun fichier ou dossier de ce type
 #include "mfu_proc.h"
          ^~~~~~~~~~~~
```

This patch include the missing file in CMakeLists and fix this issue:
```
$ cc -I/usr/include/openmpi-x86_64 test_mpfu.c -o test_mpfu
$ ./test_mpfu
```