### PR TITLE
fix: build_path off-by-one that walks one directory forever

### DIFF
--- a/src/common/mfu_flist_walk.c
+++ b/src/common/mfu_flist_walk.c
@@ -115,7 +115,7 @@ static int build_path(char* path, size_t path_len, const char* dir, const char* 
     } else {
         new_len = snprintf(path, path_len, "%s/%s", dir, name);
     }
-    if (new_len > path_len) {
+    if (new_len < 0 || (size_t) new_len >= path_len) {
         MFU_LOG(MFU_LOG_ERR, "Path name is too long, %lu chars exceeds limit %lu: '%s/%s'",
                 new_len, path_len, dir, name);
         WALK_RESULT = -1;


### PR DESCRIPTION
Infinite loop observed during a dwalk with full paths that exceed the limit.

snprintf() returns the length it would have written, excluding the null terminator, and writes at most path_len-1 characters.  Truncation therefore begins at new_len == path_len, but build_path() only rejected new_len > path_len, letting exactly one boundary value through silently truncated by a single character.

When that dropped character is the child name and the truncation lands on the '/' separator, the result is the parent directory with a trailing slash.  build_path() takes the "%s%s" branch for a dir ending in '/', so every subsequent call regenerates the identical 4095-char string.  The walk then lstat()s that path, finds a directory, re-reads it, enqueues the same path again, and never advances.